### PR TITLE
Fix banner injection, remove unnecessary permissions, and eliminate duplicate messaging

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "__MSG_extensionName__",
-    "version": "1.0",
+    "version": "1.1",
     "description": "__MSG_extensionDescription__",
     "author": "Julien LS",
     "default_locale": "fr",
@@ -11,50 +11,12 @@
         "commands",
         "scripting"
     ],
-    "host_permissions": [
-        "https://api.openai.com/*",
-        "https://*/*"
-    ],
-    "content_security_policy": {
-        "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://*;"
-    },
     "icons": {
         "16": "images/icon16.png",
         "32": "images/icon32.png",
         "48": "images/icon48.png",
         "128": "images/icon128.png"
     },
-    "content_scripts": [
-        {
-            "matches": [
-                "<all_urls>"
-            ],
-            "css": [
-                "src/styles/content.css"
-            ],
-            "js": [
-                "src/constants.js",
-                "src/utils/ui.js",
-                "src/utils/api.js",
-                "src/utils/translation.js",
-                "src/content.js"
-            ],
-            "run_at": "document_end"
-        }
-    ],
-    "web_accessible_resources": [
-        {
-            "resources": [
-                "src/constants.js",
-                "src/utils/*.js",
-                "_locales/*/*.json",
-                "images/*"
-            ],
-            "matches": [
-                "<all_urls>"
-            ]
-        }
-    ],
     "background": {
         "service_worker": "src/background.js",
         "type": "module"
@@ -81,5 +43,19 @@
             "description": "Start/Stop Recording"
         }
     },
-    "homepage_url": "https://jls42.org/"
+    "homepage_url": "https://jls42.org/",
+    "web_accessible_resources": [
+        {
+            "resources": [
+                "src/*.js",
+                "src/utils/*.js",
+                "_locales/*/*.json",
+                "images/*",
+                "src/styles/content.css"
+            ],
+            "matches": [
+                "<all_urls>"
+            ]
+        }
+    ]
 }

--- a/src/background.js
+++ b/src/background.js
@@ -65,6 +65,10 @@ async function injectContentScript(tab) {
                 'src/content.js'
             ]
         });
+        await chrome.scripting.insertCSS({
+            target: { tabId: tab.id },
+            files: ['src/styles/content.css']
+        });
         debug("Content script injected successfully");
         return true;
     } catch (error) {

--- a/src/content.js
+++ b/src/content.js
@@ -608,15 +608,4 @@
     initBanner(); // Initialise le bandeau mais ne l'affiche pas immédiatement
     console.log("Content script injected!");
 
-    // Écouter les messages du background script
-    chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-        console.log("Message received:", request);
-        if (request.action === ACTIONS.TOGGLE) {
-            if (!isRecording) {
-                startRecording();
-            } else {
-                stopRecording();
-            }
-        }
-    });
 })();


### PR DESCRIPTION
Updated extension version from 1.0 to 1.1.
Removed "host_permissions" and "content_security_policy" from the manifest to avoid installation warnings.
Removed the static "content_scripts" block from the manifest to reduce unnecessary permissions.
Implemented dynamic injection of the content script and its associated CSS (src/styles/content.css) via chrome.scripting in background.js. This ensures proper banner display without requiring global injection.
Updated the "web_accessible_resources" section in the manifest to include all necessary resources.
Eliminated a duplicated message listener that was causing messages to be received twice.
These changes improve the injection of the banner, streamline message handling, and optimize permissions while following best practices for a Chrome Manifest V3 extension.