### PR TITLE
BabelFishAI version 1.1.2

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -1,15 +1,15 @@
 {
     "extensionName": {
-        "message": "BabelFishAI by jls42.org",
-        "description": "اسم الإضافة"
+        "message": "BabelFishAI من jls42.org",
+        "description": "اسم الامتداد"
     },
     "extensionDescription": {
-        "message": "حول صوتك إلى نص مع النسخ والترجمة المدعومة بالذكاء الاصطناعي",
-        "description": "وصف الإضافة"
+        "message": "حوّل صوتك إلى نص باستخدام النسخ والترجمة المدعومين بالذكاء الاصطناعي",
+        "description": "وصف الامتداد"
     },
     "optionsTitle": {
-        "message": "إعدادات BabelFishAI",
-        "description": "عنوان صفحة الإعدادات"
+        "message": "تكوين BabelFishAI",
+        "description": "عنوان صفحة الخيارات"
     },
     "languageSettingsTitle": {
         "message": "لغة الواجهة",
@@ -24,36 +24,36 @@
         "description": "رسالة تأكيد تغيير اللغة"
     },
     "savedMessage": {
-        "message": "تم حفظ الإعدادات!",
+        "message": "تم حفظ الخيارات!",
         "description": "رسالة تأكيد الحفظ"
     },
     "apiConfigTitle": {
-        "message": "إعدادات API",
-        "description": "عنوان قسم API"
+        "message": "تكوين واجهة برمجة التطبيقات",
+        "description": "عنوان قسم واجهة برمجة التطبيقات"
     },
     "apiKeyPlaceholder": {
-        "message": "مفتاح API الخاص بـ OpenAI (sk-...)",
-        "description": "نص توضيحي لمفتاح API"
+        "message": "مفتاح واجهة برمجة تطبيقات OpenAI الخاص بك (sk-...)",
+        "description": "العنصر النائب لمفتاح API"
     },
     "apiKeyInfo": {
-        "message": "احصل على مفتاح API من",
-        "description": "معلومات الحصول على مفتاح API"
+        "message": "احصل على مفتاح API الخاص بك على",
+        "description": "معلومات حول الحصول على مفتاح API"
     },
     "pricingInfo": {
-        "message": "مزيد من المعلومات عن الأسعار متوفرة على",
+        "message": "مزيد من المعلومات حول الأسعار متوفرة على",
         "description": "معلومات التسعير"
     },
     "supportProject": {
-        "message": "دعم المشروع عبر PayPal",
-        "description": "نص رابط PayPal"
+        "message": "ادعم المشروع عبر PayPal",
+        "description": "نص لرابط دعم PayPal"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
-        "description": "عنوان URL الافتراضي لـ Whisper API"
+        "description": "عنوان URL الافتراضي لواجهة برمجة تطبيقات Whisper"
     },
     "translationApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/chat/completions",
-        "description": "عنوان URL الافتراضي لـ API الترجمة"
+        "description": "عنوان URL الافتراضي لواجهة برمجة تطبيقات الترجمة"
     },
     "displaySettingsTitle": {
         "message": "إعدادات العرض",
@@ -64,16 +64,16 @@
         "description": "تسمية العرض النشط"
     },
     "dialogDisplayLabel": {
-        "message": "مربع حوار",
+        "message": "مربع الحوار",
         "description": "تسمية عرض مربع الحوار"
     },
     "dialogDurationLabel": {
-        "message": "مدة عرض مربع الحوار (ثواني):",
+        "message": "مدة عرض مربع الحوار (بالثواني):",
         "description": "تسمية مدة مربع الحوار"
     },
     "bannerColorsLabel": {
-        "message": "ألوان شريط الحالة:",
-        "description": "تسمية ألوان الشريط"
+        "message": "ألوان شعار الحالة:",
+        "description": "تسمية ألوان الشعار"
     },
     "startColorLabel": {
         "message": "لون البداية:",
@@ -84,16 +84,16 @@
         "description": "تسمية لون النهاية"
     },
     "opacityLabel": {
-        "message": "% الشفافية",
-        "description": "تسمية الشفافية"
+        "message": "٪ عتامة",
+        "description": "تسمية التعتيم"
     },
     "translationTitle": {
-        "message": "الترجمة المدعومة بالذكاء الاصطناعي",
+        "message": "الترجمة المتكاملة بالذكاء الاصطناعي",
         "description": "عنوان قسم الترجمة"
     },
     "enableTranslationLabel": {
-        "message": "تفعيل الترجمة التلقائية",
-        "description": "تسمية تفعيل الترجمة"
+        "message": "تمكين الترجمة التلقائية",
+        "description": "تسمية لتمكين الترجمة"
     },
     "sourceLanguageLabel": {
         "message": "اللغة المصدر:",
@@ -104,16 +104,16 @@
         "description": "تسمية اللغة الهدف"
     },
     "expertModeTitle": {
-        "message": "الوضع المتقدم",
-        "description": "عنوان الوضع المتقدم"
+        "message": "وضع الخبير",
+        "description": "عنوان وضع الخبير"
     },
     "enableExpertModeLabel": {
-        "message": "تفعيل الوضع المتقدم",
-        "description": "تسمية تفعيل الوضع المتقدم"
+        "message": "تمكين وضع الخبير",
+        "description": "تسمية لتمكين وضع الخبير"
     },
     "advancedConfigTitle": {
-        "message": "الإعدادات المتقدمة",
-        "description": "عنوان الإعدادات المتقدمة"
+        "message": "التكوين المتقدم",
+        "description": "عنوان التكوين المتقدم"
     },
     "translationModelLabel": {
         "message": "نموذج الترجمة:",
@@ -121,31 +121,31 @@
     },
     "audioModelLabel": {
         "message": "نموذج الصوت:",
-        "description": "تسمية لنموذج الصوت"
+        "description": "تسمية نموذج الصوت"
     },
     "whisperApiUrlLabel": {
-        "message": "عنوان Whisper API:",
-        "description": "تسمية عنوان Whisper API"
+        "message": "عنوان URL لواجهة برمجة تطبيقات Whisper:",
+        "description": "تسمية عنوان URL لواجهة برمجة تطبيقات Whisper"
     },
     "translationApiUrlLabel": {
-        "message": "عنوان API الترجمة:",
-        "description": "تسمية عنوان API الترجمة"
+        "message": "عنوان URL لواجهة برمجة تطبيقات الترجمة:",
+        "description": "تسمية عنوان URL لواجهة برمجة تطبيقات الترجمة"
     },
     "forcedDialogDomainsLabel": {
-        "message": "النطاقات مع مربع حوار إجباري:",
-        "description": "تسمية النطاقات الإجبارية"
+        "message": "المجالات ذات مربع الحوار القسري:",
+        "description": "تسمية المجالات ذات مربع الحوار القسري"
     },
     "addDomainPlaceholder": {
         "message": "مثال: chat.google.com",
-        "description": "نص توضيحي لإضافة نطاق"
+        "description": "العنصر النائب لإضافة مجال"
     },
     "addDomainButton": {
         "message": "إضافة",
-        "description": "زر إضافة نطاق"
+        "description": "زر لإضافة مجال"
     },
     "forcedDialogInfo": {
-        "message": "في هذه النطاقات، سيظهر النص المنسوخ دائماً في مربع حوار",
-        "description": "معلومات النطاقات الإجبارية"
+        "message": "في هذه المجالات ، سيظهر النسخ دائمًا في مربع حوار",
+        "description": "معلومات حول المجالات ذات مربع الحوار القسري"
     },
     "saveButton": {
         "message": "حفظ",
@@ -160,7 +160,7 @@
         "description": "الخطوة 1 من الدليل"
     },
     "userGuideStep2": {
-        "message": "تحدث بوضوح في الميكروفون",
+        "message": "تحدث بوضوح في الميكروفون الخاص بك",
         "description": "الخطوة 2 من الدليل"
     },
     "userGuideStep3": {
@@ -168,7 +168,7 @@
         "description": "الخطوة 3 من الدليل"
     },
     "userGuideStep4": {
-        "message": "سيظهر النص المنسوخ حسب تفضيلاتك المكونة",
+        "message": "سيظهر النسخ وفقًا لتفضيلاتك التي تم تكوينها",
         "description": "الخطوة 4 من الدليل"
     },
     "userGuideStep5": {
@@ -184,15 +184,15 @@
         "description": "وصف الاختصار الرئيسي"
     },
     "shortcutKeys": {
-        "message": "Ctrl+Shift+1 (⌘+Shift+1 على Mac)",
+        "message": "Ctrl+Shift+1 (⌘+Shift+1 على نظام Mac)",
         "description": "وصف مفاتيح الاختصار"
     },
     "aiTranscriptionTitle": {
-        "message": "النسخ المدعوم بالذكاء الاصطناعي",
-        "description": "عنوان النسخ بالذكاء الاصطناعي"
+        "message": "النسخ بمساعدة الذكاء الاصطناعي",
+        "description": "عنوان قسم النسخ"
     },
     "aiTranscriptionDesc": {
-        "message": "يستخدم BabelFishAI الذكاء الاصطناعي المتطور لتحويل صوتك إلى نص. تتم عملية النسخ على خطوتين.",
+        "message": "يستخدم BabelFishAI أحدث تقنيات الذكاء الاصطناعي لنسخ صوتك إلى نص. تتم عملية النسخ على خطوتين.",
         "description": "وصف النسخ"
     },
     "aiTranscriptionStep1": {
@@ -200,15 +200,15 @@
         "description": "الخطوة 1 من النسخ"
     },
     "aiTranscriptionStep2": {
-        "message": "يتم تحليل التسجيل بواسطة Whisper AI لإنتاج نسخ دقيق",
+        "message": "يتم تحليل التسجيل بواسطة Whisper AI لإنتاج نسخة دقيقة",
         "description": "الخطوة 2 من النسخ"
     },
     "aiTranslationTitle": {
-        "message": "الترجمة المدعومة بالذكاء الاصطناعي",
-        "description": "عنوان الترجمة بالذكاء الاصطناعي"
+        "message": "الترجمة بمساعدة الذكاء الاصطناعي",
+        "description": "عنوان قسم الترجمة بالذكاء الاصطناعي"
     },
     "aiTranslationDesc": {
-        "message": "يمكن لـ BabelFishAI أيضاً ترجمة نصوصك المنسوخة تلقائياً باستخدام الذكاء الاصطناعي المتقدم من OpenAI. يتم تحليل النص المنسوخ وترجمته مع الحفاظ على المعنى والسياق.",
+        "message": "يمكن لـ BabelFishAI أيضًا ترجمة نصوصك تلقائيًا بفضل الذكاء الاصطناعي المتقدم من OpenAI. يتم تحليل النص المنسوخ وترجمته مع الحفاظ على معنى وسياق كلماتك.",
         "description": "وصف الترجمة"
     },
     "authorSectionTitle": {
@@ -216,11 +216,19 @@
         "description": "عنوان قسم المؤلف"
     },
     "authorName": {
-        "message": "Julien LS",
+        "message": "جوليان ل.س",
         "description": "اسم المؤلف"
     },
     "authorRole": {
-        "message": "مطور ومنشئ BabelFishAI",
+        "message": "مطور ومبتكر BabelFishAI",
         "description": "دور المؤلف"
+    },
+    "addModelPlaceholder": {
+        "message": "إضافة نموذج",
+        "description": "العنصر النائب لإضافة نموذج"
+    },
+    "addModelButton": {
+        "message": "إضافة",
+        "description": "زر لإضافة نموذج"
     }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,30 +1,30 @@
 {
     "extensionName": {
-        "message": "BabelFishAI by jls42.org",
+        "message": "BabelFishAI von jls42.org",
         "description": "Name der Erweiterung"
     },
     "extensionDescription": {
-        "message": "Wandeln Sie Ihre Stimme mit KI-gestützter Transkription und Übersetzung in Text um",
+        "message": "Verwandeln Sie Ihre Stimme in Text mit KI-gestützter Transkription und Übersetzung",
         "description": "Beschreibung der Erweiterung"
     },
     "optionsTitle": {
-        "message": "BabelFishAI Konfiguration",
+        "message": "BabelFishAI-Konfiguration",
         "description": "Titel der Optionsseite"
     },
     "languageSettingsTitle": {
-        "message": "Oberflächensprache",
+        "message": "Interface-Sprache",
         "description": "Titel des Sprachabschnitts"
     },
     "selectLanguageLabel": {
         "message": "Sprache auswählen:",
-        "description": "Beschriftung der Sprachauswahl"
+        "description": "Label für die Sprachauswahl"
     },
     "languageChanged": {
         "message": "Sprache erfolgreich geändert",
         "description": "Bestätigungsmeldung für Sprachänderung"
     },
     "savedMessage": {
-        "message": "Einstellungen gespeichert!",
+        "message": "Optionen gespeichert!",
         "description": "Bestätigungsmeldung für Speicherung"
     },
     "apiConfigTitle": {
@@ -32,28 +32,28 @@
         "description": "Titel des API-Abschnitts"
     },
     "apiKeyPlaceholder": {
-        "message": "Ihr OpenAI API-Schlüssel (sk-...)",
+        "message": "Ihr OpenAI-API-Schlüssel (sk-...)",
         "description": "Platzhalter für API-Schlüssel"
     },
     "apiKeyInfo": {
-        "message": "API-Schlüssel erhalten unter",
-        "description": "Information zum API-Schlüssel"
+        "message": "Holen Sie sich Ihren API-Schlüssel unter",
+        "description": "Informationen zum Abrufen des API-Schlüssels"
     },
     "pricingInfo": {
-        "message": "Weitere Preisinformationen verfügbar unter",
-        "description": "Preisinformationen"
+        "message": "Weitere Informationen zur Preisgestaltung finden Sie unter",
+        "description": "Informationen zur Preisgestaltung"
     },
     "supportProject": {
-        "message": "Projekt über PayPal unterstützen",
-        "description": "PayPal-Link-Text"
+        "message": "Unterstützen Sie das Projekt über PayPal",
+        "description": "Text für den PayPal-Support-Link"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
-        "description": "Standard-URL für Whisper API"
+        "description": "Standard-Whisper-API-URL"
     },
     "translationApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/chat/completions",
-        "description": "Standard-URL für Übersetzungs-API"
+        "description": "Standard-Übersetzungs-API-URL"
     },
     "displaySettingsTitle": {
         "message": "Anzeigeeinstellungen",
@@ -61,31 +61,31 @@
     },
     "activeDisplayLabel": {
         "message": "Aktiver Bereich (Tastatureingabe)",
-        "description": "Beschriftung aktive Anzeige"
+        "description": "Label für aktive Anzeige"
     },
     "dialogDisplayLabel": {
-        "message": "Dialogfenster",
-        "description": "Beschriftung Dialoganzeige"
+        "message": "Dialogfeld",
+        "description": "Label für Dialogfeldanzeige"
     },
     "dialogDurationLabel": {
-        "message": "Anzeigedauer des Dialogs (Sekunden):",
-        "description": "Beschriftung Dialogdauer"
+        "message": "Anzeigedauer des Dialogfelds (Sekunden):",
+        "description": "Label für Dialogdauer"
     },
     "bannerColorsLabel": {
-        "message": "Statusbanner-Farben:",
-        "description": "Beschriftung Banner-Farben"
+        "message": "Farben des Statusbanners:",
+        "description": "Label für Bannerfarben"
     },
     "startColorLabel": {
         "message": "Startfarbe:",
-        "description": "Beschriftung Startfarbe"
+        "description": "Label für Startfarbe"
     },
     "endColorLabel": {
         "message": "Endfarbe:",
-        "description": "Beschriftung Endfarbe"
+        "description": "Label für Endfarbe"
     },
     "opacityLabel": {
         "message": "% Deckkraft",
-        "description": "Beschriftung Deckkraft"
+        "description": "Label für Deckkraft"
     },
     "translationTitle": {
         "message": "Integrierte KI-Übersetzung",
@@ -93,70 +93,70 @@
     },
     "enableTranslationLabel": {
         "message": "Automatische Übersetzung aktivieren",
-        "description": "Beschriftung Übersetzung aktivieren"
+        "description": "Label für Übersetzungsaktivierung"
     },
     "sourceLanguageLabel": {
         "message": "Quellsprache:",
-        "description": "Beschriftung Quellsprache"
+        "description": "Label für Quellsprache"
     },
     "targetLanguageLabel": {
         "message": "Zielsprache:",
-        "description": "Beschriftung Zielsprache"
+        "description": "Label für Zielsprache"
     },
     "expertModeTitle": {
         "message": "Expertenmodus",
-        "description": "Titel Expertenmodus"
+        "description": "Titel des Expertenmodus"
     },
     "enableExpertModeLabel": {
         "message": "Expertenmodus aktivieren",
-        "description": "Beschriftung Expertenmodus aktivieren"
+        "description": "Label für Expertenmodusaktivierung"
     },
     "advancedConfigTitle": {
         "message": "Erweiterte Konfiguration",
-        "description": "Titel erweiterte Konfiguration"
+        "description": "Titel der erweiterten Konfiguration"
     },
     "translationModelLabel": {
         "message": "Übersetzungsmodell:",
-        "description": "Beschriftung Übersetzungsmodell"
+        "description": "Label für Übersetzungsmodell"
     },
     "audioModelLabel": {
         "message": "Audiomodell:",
-        "description": "Bezeichnung für das Audiomodell"
+        "description": "Label für Audiomodell"
     },
     "whisperApiUrlLabel": {
-        "message": "Whisper API-URL:",
-        "description": "Beschriftung Whisper API-URL"
+        "message": "Whisper-API-URL:",
+        "description": "Label für Whisper-API-URL"
     },
     "translationApiUrlLabel": {
         "message": "Übersetzungs-API-URL:",
-        "description": "Beschriftung Übersetzungs-API-URL"
+        "description": "Label für Übersetzungs-API-URL"
     },
     "forcedDialogDomainsLabel": {
-        "message": "Domains mit erzwungenem Dialog:",
-        "description": "Beschriftung erzwungene Domains"
+        "message": "Domains mit erzwungenem Dialogfeld:",
+        "description": "Label für erzwungene Dialogdomänen"
     },
     "addDomainPlaceholder": {
         "message": "Beispiel: chat.google.com",
-        "description": "Platzhalter für Domain-Hinzufügung"
+        "description": "Platzhalter für Domain hinzufügen"
     },
     "addDomainButton": {
         "message": "Hinzufügen",
-        "description": "Button für Domain-Hinzufügung"
+        "description": "Schaltfläche zum Hinzufügen einer Domain"
     },
     "forcedDialogInfo": {
-        "message": "Auf diesen Domains erscheint die Transkription immer in einem Dialogfenster",
-        "description": "Information zu erzwungenen Domains"
+        "message": "Auf diesen Domains erscheint die Transkription immer in einem Dialogfeld",
+        "description": "Informationen zu erzwungenen Dialogdomänen"
     },
     "saveButton": {
         "message": "Speichern",
-        "description": "Speichern-Button"
+        "description": "Schaltfläche zum Speichern"
     },
     "userGuideTitle": {
         "message": "Benutzerhandbuch",
-        "description": "Titel Benutzerhandbuch"
+        "description": "Titel des Benutzerhandbuchs"
     },
     "userGuideStep1": {
-        "message": "Klicken Sie auf das BabelFishAI-Symbol oder verwenden Sie die Tastenkombination zum Starten der Aufnahme",
+        "message": "Klicken Sie auf das BabelFishAI-Symbol oder verwenden Sie die Tastenkombination, um die Aufnahme zu starten",
         "description": "Schritt 1 der Anleitung"
     },
     "userGuideStep2": {
@@ -164,7 +164,7 @@
         "description": "Schritt 2 der Anleitung"
     },
     "userGuideStep3": {
-        "message": "Klicken Sie erneut oder verwenden Sie die Tastenkombination zum Stoppen der Aufnahme",
+        "message": "Klicken Sie erneut oder verwenden Sie die Tastenkombination, um die Aufnahme zu stoppen",
         "description": "Schritt 3 der Anleitung"
     },
     "userGuideStep4": {
@@ -172,55 +172,63 @@
         "description": "Schritt 4 der Anleitung"
     },
     "userGuideStep5": {
-        "message": "Verwenden Sie die \"Kopieren\"-Schaltfläche, um den Text in die Zwischenablage zu kopieren",
+        "message": "Verwenden Sie die Schaltfläche \"Kopieren\", um den Text in die Zwischenablage zu kopieren",
         "description": "Schritt 5 der Anleitung"
     },
     "shortcutsTitle": {
         "message": "Tastenkombinationen",
-        "description": "Titel Tastenkombinationen"
+        "description": "Titel der Tastenkombinationen"
     },
     "shortcutStartStop": {
         "message": "Zum Starten/Stoppen der Aufnahme:",
-        "description": "Beschreibung Haupt-Tastenkombination"
+        "description": "Beschreibung der Haupttastenkombination"
     },
     "shortcutKeys": {
-        "message": "Strg+Umschalt+1 (⌘+Umschalt+1 auf Mac)",
-        "description": "Beschreibung Tastenkombinationen"
+        "message": "Strg+Umschalt+1 (⌘+Umschalt+1 auf dem Mac)",
+        "description": "Beschreibung der Tastenkombinationstasten"
     },
     "aiTranscriptionTitle": {
         "message": "KI-gestützte Transkription",
-        "description": "Titel KI-Transkription"
+        "description": "Titel des Transkriptionsabschnitts"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAI verwendet modernste künstliche Intelligenz, um Ihre Stimme in Text umzuwandeln. Der Transkriptionsprozess erfolgt in zwei Schritten.",
-        "description": "Beschreibung Transkription"
+        "message": "BabelFishAI verwendet modernste künstliche Intelligenz, um Ihre Stimme in Text zu transkribieren. Der Transkriptionsprozess erfolgt in zwei Schritten.",
+        "description": "Beschreibung der Transkription"
     },
     "aiTranscriptionStep1": {
         "message": "Ihre Stimme wird über das Mikrofon Ihres Geräts aufgenommen",
-        "description": "Transkriptionsschritt 1"
+        "description": "Schritt 1 der Transkription"
     },
     "aiTranscriptionStep2": {
-        "message": "Die Aufnahme wird von Whisper AI analysiert, um eine genaue Transkription zu erstellen",
-        "description": "Transkriptionsschritt 2"
+        "message": "Die Aufnahme wird von der Whisper-KI analysiert, um eine genaue Transkription zu erstellen",
+        "description": "Schritt 2 der Transkription"
     },
     "aiTranslationTitle": {
         "message": "KI-gestützte Übersetzung",
-        "description": "Titel KI-Übersetzung"
+        "description": "Titel des KI-Übersetzungsabschnitts"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAI kann Ihre Transkriptionen auch automatisch mit der fortschrittlichen KI von OpenAI übersetzen. Der transkribierte Text wird analysiert und übersetzt, wobei Bedeutung und Kontext Ihrer Sprache erhalten bleiben.",
-        "description": "Beschreibung Übersetzung"
+        "message": "BabelFishAI kann Ihre Transkriptionen dank der fortschrittlichen KI von OpenAI auch automatisch übersetzen. Der transkribierte Text wird analysiert und übersetzt, wobei die Bedeutung und der Kontext Ihrer Worte erhalten bleiben.",
+        "description": "Beschreibung der Übersetzung"
     },
     "authorSectionTitle": {
         "message": "Über den Autor",
-        "description": "Titel Autorenabschnitt"
+        "description": "Titel des Autorenbereichs"
     },
     "authorName": {
         "message": "Julien LS",
         "description": "Name des Autors"
     },
     "authorRole": {
-        "message": "Entwickler und Ersteller von BabelFishAI",
+        "message": "Entwickler und Schöpfer von BabelFishAI",
         "description": "Rolle des Autors"
+    },
+    "addModelPlaceholder": {
+        "message": "Modell hinzufügen",
+        "description": "Platzhalter für Modell hinzufügen"
+    },
+    "addModelButton": {
+        "message": "Hinzufügen",
+        "description": "Schaltfläche zum Hinzufügen eines Modells"
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -4,7 +4,7 @@
         "description": "Extension name"
     },
     "extensionDescription": {
-        "message": "Transform your voice into text with AI-powered transcription and translation",
+        "message": "Turn your voice into text with AI-powered transcription and translation",
         "description": "Extension description"
     },
     "optionsTitle": {
@@ -17,7 +17,7 @@
     },
     "selectLanguageLabel": {
         "message": "Select language:",
-        "description": "Language selector label"
+        "description": "Label for language selector"
     },
     "languageChanged": {
         "message": "Language changed successfully",
@@ -33,19 +33,19 @@
     },
     "apiKeyPlaceholder": {
         "message": "Your OpenAI API key (sk-...)",
-        "description": "API key placeholder"
+        "description": "Placeholder for API key"
     },
     "apiKeyInfo": {
         "message": "Get your API key at",
-        "description": "API key information"
+        "description": "Information on obtaining API key"
     },
     "pricingInfo": {
-        "message": "More information about pricing available at",
+        "message": "More information on pricing available at",
         "description": "Pricing information"
     },
     "supportProject": {
         "message": "Support the project via PayPal",
-        "description": "PayPal support link text"
+        "description": "Text for PayPal support link"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
@@ -53,7 +53,7 @@
     },
     "translationApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/chat/completions",
-        "description": "Default Translation API URL"
+        "description": "Default translation API URL"
     },
     "displaySettingsTitle": {
         "message": "Display Settings",
@@ -61,31 +61,31 @@
     },
     "activeDisplayLabel": {
         "message": "Active area (keyboard input)",
-        "description": "Active display label"
+        "description": "Label for active display"
     },
     "dialogDisplayLabel": {
         "message": "Dialog box",
-        "description": "Dialog display label"
+        "description": "Label for dialog display"
     },
     "dialogDurationLabel": {
         "message": "Dialog display duration (seconds):",
-        "description": "Dialog duration label"
+        "description": "Label for dialog duration"
     },
     "bannerColorsLabel": {
         "message": "Status banner colors:",
-        "description": "Banner colors label"
+        "description": "Label for banner colors"
     },
     "startColorLabel": {
         "message": "Start color:",
-        "description": "Start color label"
+        "description": "Label for start color"
     },
     "endColorLabel": {
         "message": "End color:",
-        "description": "End color label"
+        "description": "Label for end color"
     },
     "opacityLabel": {
         "message": "% Opacity",
-        "description": "Opacity label"
+        "description": "Label for opacity"
     },
     "translationTitle": {
         "message": "Integrated AI Translation",
@@ -93,15 +93,15 @@
     },
     "enableTranslationLabel": {
         "message": "Enable automatic translation",
-        "description": "Enable translation label"
+        "description": "Label for enabling translation"
     },
     "sourceLanguageLabel": {
         "message": "Source language:",
-        "description": "Source language label"
+        "description": "Label for source language"
     },
     "targetLanguageLabel": {
         "message": "Target language:",
-        "description": "Target language label"
+        "description": "Label for target language"
     },
     "expertModeTitle": {
         "message": "Expert Mode",
@@ -109,7 +109,7 @@
     },
     "enableExpertModeLabel": {
         "message": "Enable expert mode",
-        "description": "Enable expert mode label"
+        "description": "Label for enabling expert mode"
     },
     "advancedConfigTitle": {
         "message": "Advanced Configuration",
@@ -117,35 +117,35 @@
     },
     "translationModelLabel": {
         "message": "Translation model:",
-        "description": "Translation model label"
+        "description": "Label for translation model"
     },
     "audioModelLabel": {
-        "message": "Audio Model:",
-        "description": "Label for the audio model"
+        "message": "Audio model:",
+        "description": "Label for audio model"
     },
     "whisperApiUrlLabel": {
         "message": "Whisper API URL:",
-        "description": "Whisper API URL label"
+        "description": "Label for Whisper API URL"
     },
     "translationApiUrlLabel": {
         "message": "Translation API URL:",
-        "description": "Translation API URL label"
+        "description": "Label for translation API URL"
     },
     "forcedDialogDomainsLabel": {
-        "message": "Domains with forced dialog:",
-        "description": "Forced dialog domains label"
+        "message": "Domains with forced dialog box:",
+        "description": "Label for forced dialog domains"
     },
     "addDomainPlaceholder": {
         "message": "Example: chat.google.com",
-        "description": "Add domain placeholder"
+        "description": "Placeholder for adding domain"
     },
     "addDomainButton": {
         "message": "Add",
-        "description": "Add domain button"
+        "description": "Button to add a domain"
     },
     "forcedDialogInfo": {
-        "message": "On these domains, transcription will always appear in a dialog box",
-        "description": "Forced dialog information"
+        "message": "On these domains, the transcription will always appear in a dialog box",
+        "description": "Information on forced dialog domains"
     },
     "saveButton": {
         "message": "Save",
@@ -157,23 +157,23 @@
     },
     "userGuideStep1": {
         "message": "Click the BabelFishAI icon or use the keyboard shortcut to start recording",
-        "description": "Guide step 1"
+        "description": "Step 1 of the guide"
     },
     "userGuideStep2": {
         "message": "Speak clearly into your microphone",
-        "description": "Guide step 2"
+        "description": "Step 2 of the guide"
     },
     "userGuideStep3": {
         "message": "Click again or use the shortcut to stop recording",
-        "description": "Guide step 3"
+        "description": "Step 3 of the guide"
     },
     "userGuideStep4": {
         "message": "The transcription will appear according to your configured preferences",
-        "description": "Guide step 4"
+        "description": "Step 4 of the guide"
     },
     "userGuideStep5": {
-        "message": "Use the \"Copy\" button to copy the text to clipboard",
-        "description": "Guide step 5"
+        "message": "Use the \"Copy\" button to copy the text to the clipboard",
+        "description": "Step 5 of the guide"
     },
     "shortcutsTitle": {
         "message": "Keyboard Shortcuts",
@@ -181,34 +181,34 @@
     },
     "shortcutStartStop": {
         "message": "To start/stop recording:",
-        "description": "Main shortcut description"
+        "description": "Description of the main shortcut"
     },
     "shortcutKeys": {
         "message": "Ctrl+Shift+1 (⌘+Shift+1 on Mac)",
-        "description": "Shortcut keys description"
+        "description": "Description of the shortcut keys"
     },
     "aiTranscriptionTitle": {
         "message": "AI-Assisted Transcription",
-        "description": "AI transcription title"
+        "description": "Transcription section title"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAI uses cutting-edge artificial intelligence to transcribe your voice into text. The transcription process happens in two steps.",
+        "message": "BabelFishAI uses cutting-edge artificial intelligence to transcribe your voice into text. The transcription process takes place in two steps.",
         "description": "Transcription description"
     },
     "aiTranscriptionStep1": {
-        "message": "Your voice is recorded through your device's microphone",
-        "description": "Transcription step 1"
+        "message": "Your voice is recorded via your device's microphone",
+        "description": "Step 1 of transcription"
     },
     "aiTranscriptionStep2": {
-        "message": "The recording is analyzed by Whisper AI to produce accurate transcription",
-        "description": "Transcription step 2"
+        "message": "The recording is analyzed by the Whisper AI to produce an accurate transcription",
+        "description": "Step 2 of transcription"
     },
     "aiTranslationTitle": {
         "message": "AI-Assisted Translation",
-        "description": "AI translation title"
+        "description": "AI translation section title"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAI can also automatically translate your transcriptions using OpenAI's advanced AI. The transcribed text is analyzed and translated while preserving the meaning and context of your speech.",
+        "message": "BabelFishAI can also automatically translate your transcriptions thanks to OpenAI's advanced AI. The transcribed text is analyzed and translated while preserving the meaning and context of your words.",
         "description": "Translation description"
     },
     "authorSectionTitle": {
@@ -217,10 +217,18 @@
     },
     "authorName": {
         "message": "Julien LS",
-        "description": "Author name"
+        "description": "Author's name"
     },
     "authorRole": {
         "message": "Developer and creator of BabelFishAI",
-        "description": "Author role"
+        "description": "Author's role"
+    },
+    "addModelPlaceholder": {
+        "message": "Add a model",
+        "description": "Placeholder for adding a model"
+    },
+    "addModelButton": {
+        "message": "Add",
+        "description": "Button to add a model"
     }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,10 +1,10 @@
 {
     "extensionName": {
-        "message": "BabelFishAI by jls42.org",
+        "message": "BabelFishAI por jls42.org",
         "description": "Nombre de la extensión"
     },
     "extensionDescription": {
-        "message": "Transforma tu voz en texto con transcripción y traducción impulsada por IA",
+        "message": "Convierte tu voz en texto con transcripción y traducción impulsadas por IA",
         "description": "Descripción de la extensión"
     },
     "optionsTitle": {
@@ -16,11 +16,11 @@
         "description": "Título de la sección de idioma"
     },
     "selectLanguageLabel": {
-        "message": "Seleccionar idioma:",
-        "description": "Etiqueta del selector de idioma"
+        "message": "Selecciona el idioma:",
+        "description": "Etiqueta para el selector de idioma"
     },
     "languageChanged": {
-        "message": "Idioma cambiado con éxito",
+        "message": "Idioma cambiado correctamente",
         "description": "Mensaje de confirmación de cambio de idioma"
     },
     "savedMessage": {
@@ -29,123 +29,123 @@
     },
     "apiConfigTitle": {
         "message": "Configuración de la API",
-        "description": "Título de la sección API"
+        "description": "Título de la sección de la API"
     },
     "apiKeyPlaceholder": {
-        "message": "Tu clave API de OpenAI (sk-...)",
-        "description": "Marcador de posición para la clave API"
+        "message": "Tu clave de API de OpenAI (sk-...)",
+        "description": "Marcador de posición para la clave de API"
     },
     "apiKeyInfo": {
-        "message": "Obtén tu clave API en",
-        "description": "Información sobre la obtención de la clave API"
+        "message": "Obtén tu clave de API en",
+        "description": "Información sobre la obtención de la clave de API"
     },
     "pricingInfo": {
         "message": "Más información sobre precios disponible en",
         "description": "Información sobre precios"
     },
     "supportProject": {
-        "message": "Apoyar el proyecto vía PayPal",
-        "description": "Texto del enlace de PayPal"
+        "message": "Apoya el proyecto a través de PayPal",
+        "description": "Texto para el enlace de soporte de PayPal"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
-        "description": "URL predeterminada de la API Whisper"
+        "description": "URL predeterminada de la API de Whisper"
     },
     "translationApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/chat/completions",
         "description": "URL predeterminada de la API de traducción"
     },
     "displaySettingsTitle": {
-        "message": "Ajustes de visualización",
-        "description": "Título de ajustes de visualización"
+        "message": "Configuración de visualización",
+        "description": "Título de la configuración de visualización"
     },
     "activeDisplayLabel": {
         "message": "Área activa (entrada de teclado)",
-        "description": "Etiqueta de visualización activa"
+        "description": "Etiqueta para la visualización activa"
     },
     "dialogDisplayLabel": {
         "message": "Cuadro de diálogo",
-        "description": "Etiqueta de visualización de diálogo"
+        "description": "Etiqueta para la visualización en cuadro de diálogo"
     },
     "dialogDurationLabel": {
-        "message": "Duración de visualización del cuadro (segundos):",
-        "description": "Etiqueta de duración del diálogo"
+        "message": "Duración de la visualización del cuadro de diálogo (segundos):",
+        "description": "Etiqueta para la duración del diálogo"
     },
     "bannerColorsLabel": {
         "message": "Colores del banner de estado:",
-        "description": "Etiqueta de colores del banner"
+        "description": "Etiqueta para los colores del banner"
     },
     "startColorLabel": {
-        "message": "Color inicial:",
-        "description": "Etiqueta de color inicial"
+        "message": "Color de inicio:",
+        "description": "Etiqueta para el color de inicio"
     },
     "endColorLabel": {
-        "message": "Color final:",
-        "description": "Etiqueta de color final"
+        "message": "Color de fin:",
+        "description": "Etiqueta para el color de fin"
     },
     "opacityLabel": {
-        "message": "% Opacidad",
-        "description": "Etiqueta de opacidad"
+        "message": "% de opacidad",
+        "description": "Etiqueta para la opacidad"
     },
     "translationTitle": {
-        "message": "Traducción IA integrada",
+        "message": "Traducción integrada con IA",
         "description": "Título de la sección de traducción"
     },
     "enableTranslationLabel": {
-        "message": "Activar traducción automática",
-        "description": "Etiqueta para activar traducción"
+        "message": "Habilitar la traducción automática",
+        "description": "Etiqueta para habilitar la traducción"
     },
     "sourceLanguageLabel": {
-        "message": "Idioma origen:",
-        "description": "Etiqueta de idioma origen"
+        "message": "Idioma de origen:",
+        "description": "Etiqueta para el idioma de origen"
     },
     "targetLanguageLabel": {
-        "message": "Idioma destino:",
-        "description": "Etiqueta de idioma destino"
+        "message": "Idioma de destino:",
+        "description": "Etiqueta para el idioma de destino"
     },
     "expertModeTitle": {
         "message": "Modo Experto",
         "description": "Título del modo experto"
     },
     "enableExpertModeLabel": {
-        "message": "Activar modo experto",
-        "description": "Etiqueta para activar modo experto"
+        "message": "Habilitar el modo experto",
+        "description": "Etiqueta para habilitar el modo experto"
     },
     "advancedConfigTitle": {
         "message": "Configuración Avanzada",
-        "description": "Título de configuración avanzada"
+        "description": "Título de la configuración avanzada"
     },
     "translationModelLabel": {
         "message": "Modelo de traducción:",
-        "description": "Etiqueta del modelo de traducción"
+        "description": "Etiqueta para el modelo de traducción"
     },
     "audioModelLabel": {
         "message": "Modelo de audio:",
         "description": "Etiqueta para el modelo de audio"
     },
     "whisperApiUrlLabel": {
-        "message": "URL de la API Whisper:",
-        "description": "Etiqueta de URL de la API Whisper"
+        "message": "URL de la API de Whisper:",
+        "description": "Etiqueta para la URL de la API de Whisper"
     },
     "translationApiUrlLabel": {
         "message": "URL de la API de traducción:",
-        "description": "Etiqueta de URL de la API de traducción"
+        "description": "Etiqueta para la URL de la API de traducción"
     },
     "forcedDialogDomainsLabel": {
-        "message": "Dominios con diálogo forzado:",
-        "description": "Etiqueta de dominios forzados"
+        "message": "Dominios con cuadro de diálogo forzado:",
+        "description": "Etiqueta para los dominios forzados"
     },
     "addDomainPlaceholder": {
         "message": "Ejemplo: chat.google.com",
-        "description": "Marcador de posición para añadir dominio"
+        "description": "Marcador de posición para agregar dominio"
     },
     "addDomainButton": {
         "message": "Añadir",
-        "description": "Botón para añadir dominio"
+        "description": "Botón para agregar un dominio"
     },
     "forcedDialogInfo": {
         "message": "En estos dominios, la transcripción siempre aparecerá en un cuadro de diálogo",
-        "description": "Información sobre dominios forzados"
+        "description": "Información sobre los dominios forzados"
     },
     "saveButton": {
         "message": "Guardar",
@@ -156,7 +156,7 @@
         "description": "Título de la guía de usuario"
     },
     "userGuideStep1": {
-        "message": "Haz clic en el icono de BabelFishAI o usa el atajo de teclado para iniciar la grabación",
+        "message": "Haz clic en el icono de BabelFishAI o usa el atajo de teclado para comenzar a grabar",
         "description": "Paso 1 de la guía"
     },
     "userGuideStep2": {
@@ -177,7 +177,7 @@
     },
     "shortcutsTitle": {
         "message": "Atajos de Teclado",
-        "description": "Título de atajos"
+        "description": "Título de los atajos"
     },
     "shortcutStartStop": {
         "message": "Para iniciar/detener la grabación:",
@@ -189,31 +189,31 @@
     },
     "aiTranscriptionTitle": {
         "message": "Transcripción Asistida por IA",
-        "description": "Título de transcripción IA"
+        "description": "Título de la sección de transcripción"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAI utiliza inteligencia artificial de vanguardia para transcribir tu voz en texto. El proceso de transcripción ocurre en dos pasos.",
-        "description": "Descripción de transcripción"
+        "message": "BabelFishAI utiliza inteligencia artificial de vanguardia para transcribir tu voz en texto. El proceso de transcripción se lleva a cabo en dos pasos.",
+        "description": "Descripción de la transcripción"
     },
     "aiTranscriptionStep1": {
         "message": "Tu voz se graba a través del micrófono de tu dispositivo",
-        "description": "Paso 1 de transcripción"
+        "description": "Paso 1 de la transcripción"
     },
     "aiTranscriptionStep2": {
-        "message": "La grabación es analizada por IA Whisper para producir una transcripción precisa",
-        "description": "Paso 2 de transcripción"
+        "message": "La grabación es analizada por la IA Whisper para producir una transcripción precisa",
+        "description": "Paso 2 de la transcripción"
     },
     "aiTranslationTitle": {
         "message": "Traducción Asistida por IA",
-        "description": "Título de traducción IA"
+        "description": "Título de la sección de traducción IA"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAI también puede traducir automáticamente tus transcripciones usando la IA avanzada de OpenAI. El texto transcrito se analiza y traduce preservando el significado y contexto de tu discurso.",
-        "description": "Descripción de traducción"
+        "message": "BabelFishAI también puede traducir automáticamente tus transcripciones gracias a la IA avanzada de OpenAI. El texto transcrito se analiza y se traduce preservando el significado y el contexto de tus palabras.",
+        "description": "Descripción de la traducción"
     },
     "authorSectionTitle": {
         "message": "Acerca del Autor",
-        "description": "Título de la sección autor"
+        "description": "Título de la sección del autor"
     },
     "authorName": {
         "message": "Julien LS",
@@ -222,5 +222,13 @@
     "authorRole": {
         "message": "Desarrollador y creador de BabelFishAI",
         "description": "Rol del autor"
+    },
+    "addModelPlaceholder": {
+        "message": "Añadir un modelo",
+        "description": "Marcador de posición para añadir un modelo"
+    },
+    "addModelButton": {
+        "message": "Añadir",
+        "description": "Botón para añadir un modelo"
     }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -222,5 +222,13 @@
     "authorRole": {
         "message": "Développeur et créateur de BabelFishAI",
         "description": "Rôle de l'auteur"
+    },
+    "addModelPlaceholder": {
+        "message": "Ajouter un modèle",
+        "description": "Placeholder pour l'ajout de modèle"
+    },
+    "addModelButton": {
+        "message": "Ajouter",
+        "description": "Bouton pour ajouter un modèle"
     }
 }

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -4,8 +4,8 @@
         "description": "एक्सटेंशन का नाम"
     },
     "extensionDescription": {
-        "message": "AI द्वारा संचालित ट्रांसक्रिप्शन और अनुवाद के साथ अपनी आवाज को टेक्स्ट में बदलें",
-        "description": "एक्सटेंशन का विवरण"
+        "message": "एआई-संचालित ट्रांसक्रिप्शन और अनुवाद के साथ अपनी आवाज को टेक्स्ट में बदलें",
+        "description": "एक्सटेंशन विवरण"
     },
     "optionsTitle": {
         "message": "BabelFishAI कॉन्फ़िगरेशन",
@@ -13,47 +13,47 @@
     },
     "languageSettingsTitle": {
         "message": "इंटरफ़ेस भाषा",
-        "description": "भाषा खंड शीर्षक"
+        "description": "भाषा अनुभाग शीर्षक"
     },
     "selectLanguageLabel": {
         "message": "भाषा चुनें:",
-        "description": "भाषा चयनकर्ता लेबल"
+        "description": "भाषा चयनकर्ता के लिए लेबल"
     },
     "languageChanged": {
-        "message": "भाषा सफलतापूर्वक बदल गई",
-        "description": "भाषा परिवर्तन पुष्टि संदेश"
+        "message": "भाषा सफलतापूर्वक बदली गई",
+        "description": "भाषा परिवर्तन पुष्टिकरण संदेश"
     },
     "savedMessage": {
         "message": "विकल्प सहेजे गए!",
-        "description": "सहेजने की पुष्टि संदेश"
+        "description": "सहेजें पुष्टिकरण संदेश"
     },
     "apiConfigTitle": {
         "message": "API कॉन्फ़िगरेशन",
-        "description": "API खंड शीर्षक"
+        "description": "API अनुभाग शीर्षक"
     },
     "apiKeyPlaceholder": {
         "message": "आपकी OpenAI API कुंजी (sk-...)",
-        "description": "API कुंजी प्लेसहोल्डर"
+        "description": "API कुंजी के लिए प्लेसहोल्डर"
     },
     "apiKeyInfo": {
-        "message": "API कुंजी यहां प्राप्त करें",
-        "description": "API कुंजी जानकारी"
+        "message": "अपनी API कुंजी यहां प्राप्त करें",
+        "description": "API कुंजी प्राप्त करने की जानकारी"
     },
     "pricingInfo": {
         "message": "मूल्य निर्धारण के बारे में अधिक जानकारी यहां उपलब्ध है",
-        "description": "मूल्य निर्धारण जानकारी"
+        "description": "मूल्य निर्धारण की जानकारी"
     },
     "supportProject": {
         "message": "PayPal के माध्यम से परियोजना का समर्थन करें",
-        "description": "PayPal लिंक टेक्स्ट"
+        "description": "PayPal समर्थन लिंक के लिए पाठ"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
-        "description": "Whisper API डिफ़ॉल्ट URL"
+        "description": "डिफ़ॉल्ट Whisper API URL"
     },
     "translationApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/chat/completions",
-        "description": "अनुवाद API डिफ़ॉल्ट URL"
+        "description": "डिफ़ॉल्ट अनुवाद API URL"
     },
     "displaySettingsTitle": {
         "message": "प्रदर्शन सेटिंग्स",
@@ -61,47 +61,47 @@
     },
     "activeDisplayLabel": {
         "message": "सक्रिय क्षेत्र (कीबोर्ड इनपुट)",
-        "description": "सक्रिय प्रदर्शन लेबल"
+        "description": "सक्रिय प्रदर्शन के लिए लेबल"
     },
     "dialogDisplayLabel": {
         "message": "संवाद बॉक्स",
-        "description": "संवाद प्रदर्शन लेबल"
+        "description": "संवाद बॉक्स प्रदर्शन के लिए लेबल"
     },
     "dialogDurationLabel": {
         "message": "संवाद प्रदर्शन अवधि (सेकंड):",
-        "description": "संवाद अवधि लेबल"
+        "description": "संवाद अवधि के लिए लेबल"
     },
     "bannerColorsLabel": {
         "message": "स्थिति बैनर रंग:",
-        "description": "बैनर रंग लेबल"
+        "description": "बैनर रंगों के लिए लेबल"
     },
     "startColorLabel": {
-        "message": "प्रारंभ रंग:",
-        "description": "प्रारंभ रंग लेबल"
+        "message": "आरंभ रंग:",
+        "description": "आरंभ रंग के लिए लेबल"
     },
     "endColorLabel": {
-        "message": "अंत रंग:",
-        "description": "अंत रंग लेबल"
+        "message": "अंतिम रंग:",
+        "description": "अंतिम रंग के लिए लेबल"
     },
     "opacityLabel": {
-        "message": "% अपारदर्शिता",
-        "description": "अपारदर्शिता लेबल"
+        "message": "% अस्पष्टता",
+        "description": "अस्पष्टता के लिए लेबल"
     },
     "translationTitle": {
-        "message": "एकीकृत AI अनुवाद",
-        "description": "अनुवाद खंड शीर्षक"
+        "message": "एकीकृत एआई अनुवाद",
+        "description": "अनुवाद अनुभाग शीर्षक"
     },
     "enableTranslationLabel": {
         "message": "स्वचालित अनुवाद सक्षम करें",
-        "description": "अनुवाद सक्षम लेबल"
+        "description": "अनुवाद सक्षम करने के लिए लेबल"
     },
     "sourceLanguageLabel": {
         "message": "स्रोत भाषा:",
-        "description": "स्रोत भाषा लेबल"
+        "description": "स्रोत भाषा के लिए लेबल"
     },
     "targetLanguageLabel": {
         "message": "लक्ष्य भाषा:",
-        "description": "लक्ष्य भाषा लेबल"
+        "description": "लक्ष्य भाषा के लिए लेबल"
     },
     "expertModeTitle": {
         "message": "विशेषज्ञ मोड",
@@ -109,118 +109,126 @@
     },
     "enableExpertModeLabel": {
         "message": "विशेषज्ञ मोड सक्षम करें",
-        "description": "विशेषज्ञ मोड सक्षम लेबल"
+        "description": "विशेषज्ञ मोड सक्षम करने के लिए लेबल"
     },
     "advancedConfigTitle": {
-        "message": "उन्नत कॉन्फ़िगरेशन",
-        "description": "उन्नत कॉन्फ़िगरेशन शीर्षक"
+        "message": "उन्नत विन्यास",
+        "description": "उन्नत विन्यास शीर्षक"
     },
     "translationModelLabel": {
         "message": "अनुवाद मॉडल:",
-        "description": "अनुवाद मॉडल लेबल"
+        "description": "अनुवाद मॉडल के लिए लेबल"
     },
     "audioModelLabel": {
         "message": "ऑडियो मॉडल:",
-        "description": "ऑडियो मॉडल लेबल"
+        "description": "ऑडियो मॉडल के लिए लेबल"
     },
     "whisperApiUrlLabel": {
         "message": "Whisper API URL:",
-        "description": "Whisper API URL लेबल"
+        "description": "Whisper API URL के लिए लेबल"
     },
     "translationApiUrlLabel": {
         "message": "अनुवाद API URL:",
-        "description": "अनुवाद API URL लेबल"
+        "description": "अनुवाद API URL के लिए लेबल"
     },
     "forcedDialogDomainsLabel": {
-        "message": "बलपूर्वक संवाद डोमेन:",
-        "description": "बलपूर्वक संवाद डोमेन लेबल"
+        "message": "जबरन डायलॉग बॉक्स वाले डोमेन:",
+        "description": "जबरन डायलॉग डोमेन के लिए लेबल"
     },
     "addDomainPlaceholder": {
         "message": "उदाहरण: chat.google.com",
-        "description": "डोमेन जोड़ें प्लेसहोल्डर"
+        "description": "डोमेन जोड़ने के लिए प्लेसहोल्डर"
     },
     "addDomainButton": {
         "message": "जोड़ें",
-        "description": "डोमेन जोड़ें बटन"
+        "description": "डोमेन जोड़ने के लिए बटन"
     },
     "forcedDialogInfo": {
-        "message": "इन डोमेन पर, ट्रांसक्रिप्शन हमेशा एक संवाद बॉक्स में दिखाई देगा",
-        "description": "बलपूर्वक संवाद जानकारी"
+        "message": "इन डोमेन पर, ट्रांसक्रिप्शन हमेशा एक डायलॉग बॉक्स में दिखाई देगा",
+        "description": "जबरन डायलॉग डोमेन के बारे में जानकारी"
     },
     "saveButton": {
         "message": "सहेजें",
         "description": "सहेजें बटन"
     },
     "userGuideTitle": {
-        "message": "उपयोगकर्ता मार्गदर्शिका",
-        "description": "उपयोगकर्ता मार्गदर्शिका शीर्षक"
+        "message": "उपयोगकर्ता गाइड",
+        "description": "उपयोगकर्ता गाइड शीर्षक"
     },
     "userGuideStep1": {
         "message": "रिकॉर्डिंग शुरू करने के लिए BabelFishAI आइकन पर क्लिक करें या कीबोर्ड शॉर्टकट का उपयोग करें",
-        "description": "मार्गदर्शिका चरण 1"
+        "description": "गाइड का चरण 1"
     },
     "userGuideStep2": {
         "message": "अपने माइक्रोफ़ोन में स्पष्ट रूप से बोलें",
-        "description": "मार्गदर्शिका चरण 2"
+        "description": "गाइड का चरण 2"
     },
     "userGuideStep3": {
-        "message": "रिकॉर्डिंग रोकने के लिए फिर से क्लिक करें या शॉर्टकट का उपयोग करें",
-        "description": "मार्गदर्शिका चरण 3"
+        "message": "रिकॉर्डिंग बंद करने के लिए फिर से क्लिक करें या शॉर्टकट का उपयोग करें",
+        "description": "गाइड का चरण 3"
     },
     "userGuideStep4": {
         "message": "ट्रांसक्रिप्शन आपकी कॉन्फ़िगर की गई प्राथमिकताओं के अनुसार दिखाई देगा",
-        "description": "मार्गदर्शिका चरण 4"
+        "description": "गाइड का चरण 4"
     },
     "userGuideStep5": {
         "message": "टेक्स्ट को क्लिपबोर्ड पर कॉपी करने के लिए \"कॉपी\" बटन का उपयोग करें",
-        "description": "मार्गदर्शिका चरण 5"
+        "description": "गाइड का चरण 5"
     },
     "shortcutsTitle": {
         "message": "कीबोर्ड शॉर्टकट",
         "description": "शॉर्टकट शीर्षक"
     },
     "shortcutStartStop": {
-        "message": "रिकॉर्डिंग शुरू/रोकने के लिए:",
+        "message": "रिकॉर्डिंग शुरू/बंद करने के लिए:",
         "description": "मुख्य शॉर्टकट विवरण"
     },
     "shortcutKeys": {
         "message": "Ctrl+Shift+1 (Mac पर ⌘+Shift+1)",
-        "description": "शॉर्टकट कुंजी विवरण"
+        "description": "शॉर्टकट कुंजियों का विवरण"
     },
     "aiTranscriptionTitle": {
-        "message": "AI-सहायक ट्रांसक्रिप्शन",
-        "description": "AI ट्रांसक्रिप्शन शीर्षक"
+        "message": "एआई-सहायता प्राप्त ट्रांसक्रिप्शन",
+        "description": "ट्रांसक्रिप्शन अनुभाग शीर्षक"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAI आपकी आवाज को टेक्स्ट में बदलने के लिए उन्नत AI का उपयोग करता है। ट्रांसक्रिप्शन प्रक्रिया दो चरणों में होती है।",
+        "message": "BabelFishAI आपकी आवाज को टेक्स्ट में ट्रांसक्रिप्ट करने के लिए अत्याधुनिक आर्टिफिशियल इंटेलिजेंस का उपयोग करता है। ट्रांसक्रिप्शन प्रक्रिया दो चरणों में होती है।",
         "description": "ट्रांसक्रिप्शन विवरण"
     },
     "aiTranscriptionStep1": {
-        "message": "आपकी आवाज आपके डिवाइस के माइक्रोफ़ोन के माध्यम से रिकॉर्ड की जाती है",
-        "description": "ट्रांसक्रिप्शन चरण 1"
+        "message": "आपकी आवाज आपके डिवाइस के माइक्रोफोन के माध्यम से रिकॉर्ड की जाती है",
+        "description": "ट्रांसक्रिप्शन का चरण 1"
     },
     "aiTranscriptionStep2": {
-        "message": "रिकॉर्डिंग का विश्लेषण Whisper AI द्वारा सटीक ट्रांसक्रिप्शन के लिए किया जाता है",
-        "description": "ट्रांसक्रिप्शन चरण 2"
+        "message": "एक सटीक ट्रांसक्रिप्शन उत्पन्न करने के लिए रिकॉर्डिंग का विश्लेषण व्हिस्पर एआई द्वारा किया जाता है",
+        "description": "ट्रांसक्रिप्शन का चरण 2"
     },
     "aiTranslationTitle": {
-        "message": "AI-सहायक अनुवाद",
-        "description": "AI अनुवाद शीर्षक"
+        "message": "एआई-सहायता प्राप्त अनुवाद",
+        "description": "एआई अनुवाद अनुभाग शीर्षक"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAI OpenAI के उन्नत AI का उपयोग करके आपके ट्रांसक्रिप्शन का स्वचालित रूप से अनुवाद भी कर सकता है। ट्रांसक्राइब किए गए टेक्स्ट का विश्लेषण किया जाता है और आपके भाषण के अर्थ और संदर्भ को बनाए रखते हुए अनुवाद किया जाता है।",
+        "message": "BabelFishAI, OpenAI के उन्नत AI की बदौलत आपके ट्रांसक्रिप्शन का स्वचालित रूप से अनुवाद भी कर सकता है। ट्रांसक्रिप्ट किए गए टेक्स्ट का विश्लेषण किया जाता है और आपके शब्दों के अर्थ और संदर्भ को संरक्षित करते हुए अनुवाद किया जाता है।",
         "description": "अनुवाद विवरण"
     },
     "authorSectionTitle": {
         "message": "लेखक के बारे में",
-        "description": "लेखक खंड शीर्षक"
+        "description": "लेखक अनुभाग शीर्षक"
     },
     "authorName": {
-        "message": "Julien LS",
+        "message": "जूलियन एलएस",
         "description": "लेखक का नाम"
     },
     "authorRole": {
         "message": "BabelFishAI के डेवलपर और निर्माता",
         "description": "लेखक की भूमिका"
+    },
+    "addModelPlaceholder": {
+        "message": "मॉडल जोड़ें",
+        "description": "मॉडल जोड़ने के लिए प्लेसहोल्डर"
+    },
+    "addModelButton": {
+        "message": "जोड़ें",
+        "description": "मॉडल जोड़ने के लिए बटन"
     }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -1,147 +1,147 @@
 {
     "extensionName": {
-        "message": "BabelFishAI by jls42.org",
+        "message": "BabelFishAI di jls42.org",
         "description": "Nome dell'estensione"
     },
     "extensionDescription": {
-        "message": "Trasforma la tua voce in testo con trascrizione e traduzione basate su IA",
+        "message": "Trasforma la tua voce in testo con la trascrizione e la traduzione basate sull'IA",
         "description": "Descrizione dell'estensione"
     },
     "optionsTitle": {
-        "message": "Configurazione BabelFishAI",
+        "message": "Configurazione di BabelFishAI",
         "description": "Titolo della pagina delle opzioni"
     },
     "languageSettingsTitle": {
         "message": "Lingua dell'interfaccia",
-        "description": "Titolo della sezione lingua"
+        "description": "Titolo della sezione della lingua"
     },
     "selectLanguageLabel": {
-        "message": "Seleziona lingua:",
-        "description": "Etichetta del selettore lingua"
+        "message": "Seleziona la lingua:",
+        "description": "Etichetta per il selettore della lingua"
     },
     "languageChanged": {
         "message": "Lingua cambiata con successo",
-        "description": "Messaggio di conferma cambio lingua"
+        "description": "Messaggio di conferma del cambio di lingua"
     },
     "savedMessage": {
         "message": "Opzioni salvate!",
-        "description": "Messaggio di conferma salvataggio"
+        "description": "Messaggio di conferma del salvataggio"
     },
     "apiConfigTitle": {
-        "message": "Configurazione API",
+        "message": "Configurazione dell'API",
         "description": "Titolo della sezione API"
     },
     "apiKeyPlaceholder": {
         "message": "La tua chiave API OpenAI (sk-...)",
-        "description": "Placeholder per la chiave API"
+        "description": "Segnaposto per la chiave API"
     },
     "apiKeyInfo": {
         "message": "Ottieni la tua chiave API su",
-        "description": "Informazioni sulla chiave API"
+        "description": "Informazioni sull'ottenimento della chiave API"
     },
     "pricingInfo": {
         "message": "Maggiori informazioni sui prezzi disponibili su",
         "description": "Informazioni sui prezzi"
     },
     "supportProject": {
-        "message": "Supporta il progetto via PayPal",
-        "description": "Testo del link PayPal"
+        "message": "Sostieni il progetto tramite PayPal",
+        "description": "Testo per il link di supporto PayPal"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
-        "description": "URL predefinito API Whisper"
+        "description": "URL predefinito dell'API Whisper"
     },
     "translationApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/chat/completions",
-        "description": "URL predefinito API di traduzione"
+        "description": "URL predefinito dell'API di traduzione"
     },
     "displaySettingsTitle": {
         "message": "Impostazioni di visualizzazione",
-        "description": "Titolo impostazioni di visualizzazione"
+        "description": "Titolo delle impostazioni di visualizzazione"
     },
     "activeDisplayLabel": {
         "message": "Area attiva (input da tastiera)",
-        "description": "Etichetta visualizzazione attiva"
+        "description": "Etichetta per la visualizzazione attiva"
     },
     "dialogDisplayLabel": {
         "message": "Finestra di dialogo",
-        "description": "Etichetta visualizzazione dialogo"
+        "description": "Etichetta per la visualizzazione nella finestra di dialogo"
     },
     "dialogDurationLabel": {
-        "message": "Durata visualizzazione finestra (secondi):",
-        "description": "Etichetta durata dialogo"
+        "message": "Durata di visualizzazione della finestra di dialogo (secondi):",
+        "description": "Etichetta per la durata della finestra di dialogo"
     },
     "bannerColorsLabel": {
-        "message": "Colori banner di stato:",
-        "description": "Etichetta colori banner"
+        "message": "Colori del banner di stato:",
+        "description": "Etichetta per i colori del banner"
     },
     "startColorLabel": {
         "message": "Colore iniziale:",
-        "description": "Etichetta colore iniziale"
+        "description": "Etichetta per il colore iniziale"
     },
     "endColorLabel": {
         "message": "Colore finale:",
-        "description": "Etichetta colore finale"
+        "description": "Etichetta per il colore finale"
     },
     "opacityLabel": {
         "message": "% Opacità",
-        "description": "Etichetta opacità"
+        "description": "Etichetta per l'opacità"
     },
     "translationTitle": {
-        "message": "Traduzione IA Integrata",
-        "description": "Titolo sezione traduzione"
+        "message": "Traduzione integrata con IA",
+        "description": "Titolo della sezione di traduzione"
     },
     "enableTranslationLabel": {
-        "message": "Attiva traduzione automatica",
-        "description": "Etichetta per attivare traduzione"
+        "message": "Abilita la traduzione automatica",
+        "description": "Etichetta per abilitare la traduzione"
     },
     "sourceLanguageLabel": {
         "message": "Lingua di origine:",
-        "description": "Etichetta lingua di origine"
+        "description": "Etichetta per la lingua di origine"
     },
     "targetLanguageLabel": {
         "message": "Lingua di destinazione:",
-        "description": "Etichetta lingua di destinazione"
+        "description": "Etichetta per la lingua di destinazione"
     },
     "expertModeTitle": {
         "message": "Modalità Esperto",
-        "description": "Titolo modalità esperto"
+        "description": "Titolo della modalità esperto"
     },
     "enableExpertModeLabel": {
-        "message": "Attiva modalità esperto",
-        "description": "Etichetta per attivare modalità esperto"
+        "message": "Abilita la modalità esperto",
+        "description": "Etichetta per abilitare la modalità esperto"
     },
     "advancedConfigTitle": {
         "message": "Configurazione Avanzata",
-        "description": "Titolo configurazione avanzata"
+        "description": "Titolo della configurazione avanzata"
     },
     "translationModelLabel": {
         "message": "Modello di traduzione:",
-        "description": "Etichetta modello di traduzione"
+        "description": "Etichetta per il modello di traduzione"
     },
     "audioModelLabel": {
         "message": "Modello audio:",
         "description": "Etichetta per il modello audio"
     },
     "whisperApiUrlLabel": {
-        "message": "URL API Whisper:",
-        "description": "Etichetta URL API Whisper"
+        "message": "URL dell'API Whisper:",
+        "description": "Etichetta per l'URL dell'API Whisper"
     },
     "translationApiUrlLabel": {
-        "message": "URL API di traduzione:",
-        "description": "Etichetta URL API di traduzione"
+        "message": "URL dell'API di traduzione:",
+        "description": "Etichetta per l'URL dell'API di traduzione"
     },
     "forcedDialogDomainsLabel": {
         "message": "Domini con finestra di dialogo forzata:",
-        "description": "Etichetta domini forzati"
+        "description": "Etichetta per i domini forzati"
     },
     "addDomainPlaceholder": {
         "message": "Esempio: chat.google.com",
-        "description": "Placeholder per aggiungere dominio"
+        "description": "Segnaposto per l'aggiunta di un dominio"
     },
     "addDomainButton": {
         "message": "Aggiungi",
-        "description": "Pulsante per aggiungere dominio"
+        "description": "Pulsante per aggiungere un dominio"
     },
     "forcedDialogInfo": {
         "message": "Su questi domini, la trascrizione apparirà sempre in una finestra di dialogo",
@@ -149,71 +149,71 @@
     },
     "saveButton": {
         "message": "Salva",
-        "description": "Pulsante salva"
+        "description": "Pulsante di salvataggio"
     },
     "userGuideTitle": {
-        "message": "Guida Utente",
-        "description": "Titolo guida utente"
+        "message": "Guida per l'Utente",
+        "description": "Titolo della guida per l'utente"
     },
     "userGuideStep1": {
-        "message": "Clicca sull'icona BabelFishAI o usa la scorciatoia da tastiera per iniziare la registrazione",
-        "description": "Passo 1 della guida"
+        "message": "Fai clic sull'icona di BabelFishAI o utilizza la scorciatoia da tastiera per avviare la registrazione",
+        "description": "Passaggio 1 della guida"
     },
     "userGuideStep2": {
-        "message": "Parla chiaramente nel microfono",
-        "description": "Passo 2 della guida"
+        "message": "Parla chiaramente nel tuo microfono",
+        "description": "Passaggio 2 della guida"
     },
     "userGuideStep3": {
-        "message": "Clicca di nuovo o usa la scorciatoia per fermare la registrazione",
-        "description": "Passo 3 della guida"
+        "message": "Fai di nuovo clic o utilizza la scorciatoia per interrompere la registrazione",
+        "description": "Passaggio 3 della guida"
     },
     "userGuideStep4": {
-        "message": "La trascrizione apparirà secondo le tue preferenze configurate",
-        "description": "Passo 4 della guida"
+        "message": "La trascrizione apparirà in base alle tue preferenze configurate",
+        "description": "Passaggio 4 della guida"
     },
     "userGuideStep5": {
-        "message": "Usa il pulsante \"Copia\" per copiare il testo negli appunti",
-        "description": "Passo 5 della guida"
+        "message": "Utilizza il pulsante \"Copia\" per copiare il testo negli appunti",
+        "description": "Passaggio 5 della guida"
     },
     "shortcutsTitle": {
         "message": "Scorciatoie da Tastiera",
-        "description": "Titolo scorciatoie"
+        "description": "Titolo delle scorciatoie"
     },
     "shortcutStartStop": {
-        "message": "Per iniziare/fermare la registrazione:",
-        "description": "Descrizione scorciatoia principale"
+        "message": "Per avviare/interrompere la registrazione:",
+        "description": "Descrizione della scorciatoia principale"
     },
     "shortcutKeys": {
         "message": "Ctrl+Shift+1 (⌘+Shift+1 su Mac)",
-        "description": "Descrizione tasti scorciatoia"
+        "description": "Descrizione dei tasti di scelta rapida"
     },
     "aiTranscriptionTitle": {
-        "message": "Trascrizione Assistita da IA",
-        "description": "Titolo trascrizione IA"
+        "message": "Trascrizione Assistita dall'IA",
+        "description": "Titolo della sezione di trascrizione"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAI utilizza l'intelligenza artificiale all'avanguardia per trascrivere la tua voce in testo. Il processo di trascrizione avviene in due fasi.",
-        "description": "Descrizione trascrizione"
+        "message": "BabelFishAI utilizza l'intelligenza artificiale all'avanguardia per trascrivere la tua voce in testo. Il processo di trascrizione si svolge in due passaggi.",
+        "description": "Descrizione della trascrizione"
     },
     "aiTranscriptionStep1": {
-        "message": "La tua voce viene registrata attraverso il microfono del dispositivo",
-        "description": "Passo 1 trascrizione"
+        "message": "La tua voce viene registrata tramite il microfono del tuo dispositivo",
+        "description": "Passaggio 1 della trascrizione"
     },
     "aiTranscriptionStep2": {
-        "message": "La registrazione viene analizzata da Whisper AI per produrre una trascrizione accurata",
-        "description": "Passo 2 trascrizione"
+        "message": "La registrazione viene analizzata dall'IA Whisper per produrre una trascrizione accurata",
+        "description": "Passaggio 2 della trascrizione"
     },
     "aiTranslationTitle": {
-        "message": "Traduzione Assistita da IA",
-        "description": "Titolo traduzione IA"
+        "message": "Traduzione Assistita dall'IA",
+        "description": "Titolo della sezione di traduzione IA"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAI può anche tradurre automaticamente le tue trascrizioni utilizzando l'IA avanzata di OpenAI. Il testo trascritto viene analizzato e tradotto preservando il significato e il contesto del tuo discorso.",
-        "description": "Descrizione traduzione"
+        "message": "BabelFishAI può anche tradurre automaticamente le tue trascrizioni grazie all'IA avanzata di OpenAI. Il testo trascritto viene analizzato e tradotto preservando il significato e il contesto delle tue parole.",
+        "description": "Descrizione della traduzione"
     },
     "authorSectionTitle": {
         "message": "Informazioni sull'Autore",
-        "description": "Titolo sezione autore"
+        "description": "Titolo della sezione dell'autore"
     },
     "authorName": {
         "message": "Julien LS",
@@ -222,5 +222,13 @@
     "authorRole": {
         "message": "Sviluppatore e creatore di BabelFishAI",
         "description": "Ruolo dell'autore"
+    },
+    "addModelPlaceholder": {
+        "message": "Aggiungi un modello",
+        "description": "Segnaposto per l'aggiunta di un modello"
+    },
+    "addModelButton": {
+        "message": "Aggiungi",
+        "description": "Pulsante per aggiungere un modello"
     }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,14 +1,14 @@
 {
     "extensionName": {
         "message": "BabelFishAI by jls42.org",
-        "description": "拡張機能の名前"
+        "description": "拡張機能名"
     },
     "extensionDescription": {
-        "message": "AI駆動の文字起こしと翻訳であなたの声をテキストに変換",
+        "message": "AIを活用した文字起こしと翻訳で、あなたの声をテキストに変換します",
         "description": "拡張機能の説明"
     },
     "optionsTitle": {
-        "message": "BabelFishAI 設定",
+        "message": "BabelFishAI の設定",
         "description": "オプションページのタイトル"
     },
     "languageSettingsTitle": {
@@ -16,44 +16,44 @@
         "description": "言語セクションのタイトル"
     },
     "selectLanguageLabel": {
-        "message": "言語を選択:",
-        "description": "言語選択のラベル"
+        "message": "言語を選択：",
+        "description": "言語セレクタのラベル"
     },
     "languageChanged": {
-        "message": "言語が変更されました",
+        "message": "言語が正常に変更されました",
         "description": "言語変更の確認メッセージ"
     },
     "savedMessage": {
-        "message": "設定を保存しました！",
+        "message": "オプションを保存しました！",
         "description": "保存確認メッセージ"
     },
     "apiConfigTitle": {
-        "message": "API設定",
-        "description": "APIセクションのタイトル"
+        "message": "API の設定",
+        "description": "API セクションのタイトル"
     },
     "apiKeyPlaceholder": {
-        "message": "OpenAI APIキー (sk-...)",
-        "description": "APIキーのプレースホルダー"
+        "message": "OpenAI API キー (sk-...)",
+        "description": "API キーのプレースホルダー"
     },
     "apiKeyInfo": {
-        "message": "APIキーの取得先:",
-        "description": "APIキーの情報"
+        "message": "API キーを取得する",
+        "description": "API キーの取得に関する情報"
     },
     "pricingInfo": {
-        "message": "価格の詳細はこちら:",
+        "message": "価格の詳細については、こちらをご覧ください",
         "description": "価格情報"
     },
     "supportProject": {
-        "message": "PayPalでプロジェクトを支援",
-        "description": "PayPalリンクのテキスト"
+        "message": "PayPal でプロジェクトをサポートする",
+        "description": "PayPal サポートリンクのテキスト"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
-        "description": "Whisper APIのデフォルトURL"
+        "description": "デフォルトの Whisper API URL"
     },
     "translationApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/chat/completions",
-        "description": "翻訳APIのデフォルトURL"
+        "description": "デフォルトの翻訳 API URL"
     },
     "displaySettingsTitle": {
         "message": "表示設定",
@@ -65,42 +65,42 @@
     },
     "dialogDisplayLabel": {
         "message": "ダイアログボックス",
-        "description": "ダイアログ表示のラベル"
+        "description": "ダイアログボックス表示のラベル"
     },
     "dialogDurationLabel": {
-        "message": "ダイアログ表示時間（秒）:",
-        "description": "ダイアログ時間のラベル"
+        "message": "ダイアログ表示時間（秒）：",
+        "description": "ダイアログ期間のラベル"
     },
     "bannerColorsLabel": {
-        "message": "ステータスバナーの色:",
-        "description": "バナー色のラベル"
+        "message": "ステータスバーの色：",
+        "description": "バナーカラーのラベル"
     },
     "startColorLabel": {
-        "message": "開始色:",
+        "message": "開始色：",
         "description": "開始色のラベル"
     },
     "endColorLabel": {
-        "message": "終了色:",
+        "message": "終了色：",
         "description": "終了色のラベル"
     },
     "opacityLabel": {
-        "message": "% 不透明度",
+        "message": "％ 不透明度",
         "description": "不透明度のラベル"
     },
     "translationTitle": {
-        "message": "AI翻訳機能",
+        "message": "統合 AI 翻訳",
         "description": "翻訳セクションのタイトル"
     },
     "enableTranslationLabel": {
         "message": "自動翻訳を有効にする",
-        "description": "翻訳有効化のラベル"
+        "description": "翻訳を有効にするためのラベル"
     },
     "sourceLanguageLabel": {
-        "message": "ソース言語:",
+        "message": "ソース言語：",
         "description": "ソース言語のラベル"
     },
     "targetLanguageLabel": {
-        "message": "ターゲット言語:",
+        "message": "ターゲット言語：",
         "description": "ターゲット言語のラベル"
     },
     "expertModeTitle": {
@@ -109,14 +109,14 @@
     },
     "enableExpertModeLabel": {
         "message": "エキスパートモードを有効にする",
-        "description": "エキスパートモード有効化のラベル"
+        "description": "エキスパートモードを有効にするためのラベル"
     },
     "advancedConfigTitle": {
         "message": "詳細設定",
         "description": "詳細設定のタイトル"
     },
     "translationModelLabel": {
-        "message": "翻訳モデル:",
+        "message": "翻訳モデル：",
         "description": "翻訳モデルのラベル"
     },
     "audioModelLabel": {
@@ -124,28 +124,28 @@
         "description": "オーディオモデルのラベル"
     },
     "whisperApiUrlLabel": {
-        "message": "Whisper API URL:",
-        "description": "Whisper API URLのラベル"
+        "message": "Whisper API URL：",
+        "description": "Whisper API URL のラベル"
     },
     "translationApiUrlLabel": {
-        "message": "翻訳API URL:",
-        "description": "翻訳API URLのラベル"
+        "message": "翻訳 API URL：",
+        "description": "翻訳 API URL のラベル"
     },
     "forcedDialogDomainsLabel": {
-        "message": "強制ダイアログドメイン:",
+        "message": "強制ダイアログドメイン：",
         "description": "強制ダイアログドメインのラベル"
     },
     "addDomainPlaceholder": {
-        "message": "例: chat.google.com",
+        "message": "例：chat.google.com",
         "description": "ドメイン追加のプレースホルダー"
     },
     "addDomainButton": {
         "message": "追加",
-        "description": "ドメイン追加ボタン"
+        "description": "ドメインを追加するボタン"
     },
     "forcedDialogInfo": {
-        "message": "これらのドメインでは、文字起こしは常にダイアログボックスで表示されます",
-        "description": "強制ダイアログの情報"
+        "message": "これらのドメインでは、文字起こしは常にダイアログボックスに表示されます",
+        "description": "強制ダイアログドメインに関する情報"
     },
     "saveButton": {
         "message": "保存",
@@ -156,71 +156,79 @@
         "description": "ユーザーガイドのタイトル"
     },
     "userGuideStep1": {
-        "message": "BabelFishAIアイコンをクリックするか、キーボードショートカットを使用して録音を開始",
-        "description": "ガイドのステップ1"
+        "message": "BabelFishAI アイコンをクリックするか、キーボードショートカットを使用して録音を開始します",
+        "description": "ガイドのステップ 1"
     },
     "userGuideStep2": {
-        "message": "マイクに向かってはっきりと話す",
-        "description": "ガイドのステップ2"
+        "message": "マイクに向かってはっきりと話します",
+        "description": "ガイドのステップ 2"
     },
     "userGuideStep3": {
-        "message": "もう一度クリックするか、ショートカットを使用して録音を停止",
-        "description": "ガイドのステップ3"
+        "message": "もう一度クリックするか、ショートカットを使用して録音を停止します",
+        "description": "ガイドのステップ 3"
     },
     "userGuideStep4": {
-        "message": "設定した環境設定に従って文字起こしが表示されます",
-        "description": "ガイドのステップ4"
+        "message": "設定した設定に従って文字起こしが表示されます",
+        "description": "ガイドのステップ 4"
     },
     "userGuideStep5": {
-        "message": "「コピー」ボタンを使用してテキストをクリップボードにコピー",
-        "description": "ガイドのステップ5"
+        "message": "「コピー」ボタンを使用してテキストをクリップボードにコピーします",
+        "description": "ガイドのステップ 5"
     },
     "shortcutsTitle": {
         "message": "キーボードショートカット",
         "description": "ショートカットのタイトル"
     },
     "shortcutStartStop": {
-        "message": "録音開始/停止:",
+        "message": "録音を開始/停止するには：",
         "description": "メインショートカットの説明"
     },
     "shortcutKeys": {
-        "message": "Ctrl+Shift+1（Macでは⌘+Shift+1）",
+        "message": "Ctrl+Shift+1 (Mac では ⌘+Shift+1)",
         "description": "ショートカットキーの説明"
     },
     "aiTranscriptionTitle": {
-        "message": "AI支援文字起こし",
-        "description": "AI文字起こしのタイトル"
+        "message": "AI 支援文字起こし",
+        "description": "文字起こしセクションのタイトル"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAIは最先端の人工知能を使用してあなたの声をテキストに変換します。文字起こしプロセスは2段階で行われます。",
+        "message": "BabelFishAI は、最先端の人工知能を使用して音声をテキストに書き起こします。文字起こしプロセスは 2 つのステップで行われます。",
         "description": "文字起こしの説明"
     },
     "aiTranscriptionStep1": {
-        "message": "デバイスのマイクを通じて音声を録音",
-        "description": "文字起こしステップ1"
+        "message": "あなたの声は、デバイスのマイクを介して録音されます",
+        "description": "文字起こしのステップ 1"
     },
     "aiTranscriptionStep2": {
-        "message": "Whisper AIが録音を分析して正確な文字起こしを生成",
-        "description": "文字起こしステップ2"
+        "message": "録音は Whisper AI によって分析され、正確な文字起こしが生成されます",
+        "description": "文字起こしのステップ 2"
     },
     "aiTranslationTitle": {
-        "message": "AI支援翻訳",
-        "description": "AI翻訳のタイトル"
+        "message": "AI 支援翻訳",
+        "description": "AI 翻訳セクションのタイトル"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAIはOpenAIの高度なAIを使用して文字起こしを自動的に翻訳することもできます。文字起こしされたテキストは分析され、意味とコンテキストを保持したまま翻訳されます。",
+        "message": "BabelFishAI は、OpenAI の高度な AI のおかげで、文字起こしを自動的に翻訳することもできます。文字起こしされたテキストは、あなたの言葉の意味と文脈を保持しながら分析および翻訳されます。",
         "description": "翻訳の説明"
     },
     "authorSectionTitle": {
-        "message": "作者について",
-        "description": "作者セクションのタイトル"
+        "message": "著者について",
+        "description": "著者セクションのタイトル"
     },
     "authorName": {
-        "message": "Julien LS",
-        "description": "作者の名前"
+        "message": "ジュリアン LS",
+        "description": "著者の名前"
     },
     "authorRole": {
-        "message": "BabelFishAIの開発者および作成者",
-        "description": "作者の役割"
+        "message": "BabelFishAI の開発者および作成者",
+        "description": "著者の役割"
+    },
+    "addModelPlaceholder": {
+        "message": "モデルを追加",
+        "description": "モデル追加のプレースホルダー"
+    },
+    "addModelButton": {
+        "message": "追加",
+        "description": "モデル追加ボタン"
     }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1,14 +1,14 @@
 {
     "extensionName": {
-        "message": "BabelFishAI by jls42.org",
+        "message": "jls42.org의 BabelFishAI",
         "description": "확장 프로그램 이름"
     },
     "extensionDescription": {
-        "message": "AI 기반 음성 인식과 번역으로 음성을 텍스트로 변환",
+        "message": "AI 기반 음성 텍스트 변환 및 번역으로 음성을 텍스트로 변환",
         "description": "확장 프로그램 설명"
     },
     "optionsTitle": {
-        "message": "BabelFishAI 설정",
+        "message": "BabelFishAI 구성",
         "description": "옵션 페이지 제목"
     },
     "languageSettingsTitle": {
@@ -17,91 +17,91 @@
     },
     "selectLanguageLabel": {
         "message": "언어 선택:",
-        "description": "언어 선택기 라벨"
+        "description": "언어 선택기 레이블"
     },
     "languageChanged": {
-        "message": "언어가 변경되었습니다",
+        "message": "언어가 성공적으로 변경되었습니다.",
         "description": "언어 변경 확인 메시지"
     },
     "savedMessage": {
-        "message": "설정이 저장되었습니다!",
+        "message": "옵션이 저장되었습니다!",
         "description": "저장 확인 메시지"
     },
     "apiConfigTitle": {
-        "message": "API 설정",
+        "message": "API 구성",
         "description": "API 섹션 제목"
     },
     "apiKeyPlaceholder": {
         "message": "OpenAI API 키 (sk-...)",
-        "description": "API 키 플레이스홀더"
+        "description": "API 키 자리 표시자"
     },
     "apiKeyInfo": {
-        "message": "API 키 받기:",
-        "description": "API 키 정보"
+        "message": "API 키 받기",
+        "description": "API 키 얻기에 대한 정보"
     },
     "pricingInfo": {
-        "message": "가격 정보 자세히 보기:",
+        "message": "가격에 대한 자세한 내용은 다음을 참조하십시오.",
         "description": "가격 정보"
     },
     "supportProject": {
-        "message": "PayPal로 프로젝트 지원하기",
-        "description": "PayPal 링크 텍스트"
+        "message": "PayPal을 통해 프로젝트 지원",
+        "description": "PayPal 지원 링크 텍스트"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
-        "description": "Whisper API 기본 URL"
+        "description": "기본 Whisper API URL"
     },
     "translationApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/chat/completions",
-        "description": "번역 API 기본 URL"
+        "description": "기본 번역 API URL"
     },
     "displaySettingsTitle": {
-        "message": "화면 설정",
-        "description": "화면 설정 제목"
+        "message": "디스플레이 설정",
+        "description": "디스플레이 설정 제목"
     },
     "activeDisplayLabel": {
         "message": "활성 영역 (키보드 입력)",
-        "description": "활성 표시 라벨"
+        "description": "활성 디스플레이 레이블"
     },
     "dialogDisplayLabel": {
         "message": "대화 상자",
-        "description": "대화 상자 표시 라벨"
+        "description": "대화 상자 표시 레이블"
     },
     "dialogDurationLabel": {
         "message": "대화 상자 표시 시간 (초):",
-        "description": "대화 상자 시간 라벨"
+        "description": "대화 상자 지속 시간 레이블"
     },
     "bannerColorsLabel": {
         "message": "상태 배너 색상:",
-        "description": "배너 색상 라벨"
+        "description": "배너 색상 레이블"
     },
     "startColorLabel": {
         "message": "시작 색상:",
-        "description": "시작 색상 라벨"
+        "description": "시작 색상 레이블"
     },
     "endColorLabel": {
         "message": "종료 색상:",
-        "description": "종료 색상 라벨"
+        "description": "종료 색상 레이블"
     },
     "opacityLabel": {
         "message": "% 불투명도",
-        "description": "불투명도 라벨"
+        "description": "불투명도 레이블"
     },
     "translationTitle": {
-        "message": "AI 번역 통합",
+        "message": "통합 AI 번역",
         "description": "번역 섹션 제목"
     },
     "enableTranslationLabel": {
         "message": "자동 번역 활성화",
-        "description": "번역 활성화 라벨"
+        "description": "번역 활성화 레이블"
     },
     "sourceLanguageLabel": {
-        "message": "원본 언어:",
-        "description": "원본 언어 라벨"
+        "message": "소스 언어:",
+        "description": "소스 언어 레이블"
     },
     "targetLanguageLabel": {
         "message": "대상 언어:",
-        "description": "대상 언어 라벨"
+        "description": "대상 언어 레이블"
     },
     "expertModeTitle": {
         "message": "전문가 모드",
@@ -109,43 +109,43 @@
     },
     "enableExpertModeLabel": {
         "message": "전문가 모드 활성화",
-        "description": "전문가 모드 활성화 라벨"
+        "description": "전문가 모드 활성화 레이블"
     },
     "advancedConfigTitle": {
-        "message": "고급 설정",
-        "description": "고급 설정 제목"
+        "message": "고급 구성",
+        "description": "고급 구성 제목"
     },
     "translationModelLabel": {
         "message": "번역 모델:",
-        "description": "번역 모델 라벨"
+        "description": "번역 모델 레이블"
     },
     "audioModelLabel": {
         "message": "오디오 모델:",
-        "description": "오디오 모델 라벨"
+        "description": "오디오 모델 레이블"
     },
     "whisperApiUrlLabel": {
         "message": "Whisper API URL:",
-        "description": "Whisper API URL 라벨"
+        "description": "Whisper API URL 레이블"
     },
     "translationApiUrlLabel": {
         "message": "번역 API URL:",
-        "description": "번역 API URL 라벨"
+        "description": "번역 API URL 레이블"
     },
     "forcedDialogDomainsLabel": {
         "message": "강제 대화 상자 도메인:",
-        "description": "강제 도메인 라벨"
+        "description": "강제 대화 상자 도메인 레이블"
     },
     "addDomainPlaceholder": {
         "message": "예: chat.google.com",
-        "description": "도메인 추가 플레이스홀더"
+        "description": "도메인 추가 자리 표시자"
     },
     "addDomainButton": {
         "message": "추가",
         "description": "도메인 추가 버튼"
     },
     "forcedDialogInfo": {
-        "message": "이 도메인에서는 음성 인식 결과가 항상 대화 상자로 표시됩니다",
-        "description": "강제 도메인 정보"
+        "message": "이 도메인에서는 음성 텍스트 변환이 항상 대화 상자에 나타납니다.",
+        "description": "강제 대화 상자 도메인 정보"
     },
     "saveButton": {
         "message": "저장",
@@ -156,24 +156,24 @@
         "description": "사용자 가이드 제목"
     },
     "userGuideStep1": {
-        "message": "BabelFishAI 아이콘을 클릭하거나 키보드 단축키를 사용하여 녹음 시작",
-        "description": "가이드 단계 1"
+        "message": "BabelFishAI 아이콘을 클릭하거나 키보드 단축키를 사용하여 녹음을 시작합니다.",
+        "description": "가이드 1단계"
     },
     "userGuideStep2": {
-        "message": "마이크에 대고 명확하게 말하기",
-        "description": "가이드 단계 2"
+        "message": "마이크에 대고 또렷하게 말하세요.",
+        "description": "가이드 2단계"
     },
     "userGuideStep3": {
-        "message": "다시 클릭하거나 단축키를 사용하여 녹음 중지",
-        "description": "가이드 단계 3"
+        "message": "다시 클릭하거나 바로 가기를 사용하여 녹음을 중지합니다.",
+        "description": "가이드 3단계"
     },
     "userGuideStep4": {
-        "message": "설정된 환경 설정에 따라 음성 인식 결과가 표시됩니다",
-        "description": "가이드 단계 4"
+        "message": "구성된 기본 설정에 따라 음성 텍스트 변환이 나타납니다.",
+        "description": "가이드 4단계"
     },
     "userGuideStep5": {
-        "message": "\"복사\" 버튼을 사용하여 텍스트를 클립보드에 복사",
-        "description": "가이드 단계 5"
+        "message": "\"복사\" 버튼을 사용하여 텍스트를 클립보드에 복사합니다.",
+        "description": "가이드 5단계"
     },
     "shortcutsTitle": {
         "message": "키보드 단축키",
@@ -181,46 +181,54 @@
     },
     "shortcutStartStop": {
         "message": "녹음 시작/중지:",
-        "description": "주요 단축키 설명"
+        "description": "기본 단축키 설명"
     },
     "shortcutKeys": {
         "message": "Ctrl+Shift+1 (Mac에서는 ⌘+Shift+1)",
         "description": "단축키 설명"
     },
     "aiTranscriptionTitle": {
-        "message": "AI 음성 인식",
-        "description": "AI 음성 인식 제목"
+        "message": "AI 지원 음성 텍스트 변환",
+        "description": "음성 텍스트 변환 섹션 제목"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAI는 최첨단 인공지능을 사용하여 음성을 텍스트로 변환합니다. 음성 인식 과정은 두 단계로 진행됩니다.",
-        "description": "음성 인식 설명"
+        "message": "BabelFishAI는 최첨단 인공 지능을 사용하여 음성을 텍스트로 변환합니다. 음성 텍스트 변환 프로세스는 두 단계로 진행됩니다.",
+        "description": "음성 텍스트 변환 설명"
     },
     "aiTranscriptionStep1": {
-        "message": "기기의 마이크를 통해 음성이 녹음됩니다",
-        "description": "음성 인식 단계 1"
+        "message": "장치의 마이크를 통해 음성이 녹음됩니다.",
+        "description": "음성 텍스트 변환 1단계"
     },
     "aiTranscriptionStep2": {
-        "message": "Whisper AI가 녹음을 분석하여 정확한 음성 인식을 생성합니다",
-        "description": "음성 인식 단계 2"
+        "message": "Whisper AI가 녹음을 분석하여 정확한 음성 텍스트 변환을 생성합니다.",
+        "description": "음성 텍스트 변환 2단계"
     },
     "aiTranslationTitle": {
-        "message": "AI 번역",
-        "description": "AI 번역 제목"
+        "message": "AI 지원 번역",
+        "description": "AI 번역 섹션 제목"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAI는 OpenAI의 고급 AI를 사용하여 음성 인식 결과를 자동으로 번역할 수 있습니다. 인식된 텍스트는 의미와 맥락을 유지하면서 분석되고 번역됩니다.",
+        "message": "BabelFishAI는 OpenAI의 고급 AI 덕분에 음성 텍스트 변환을 자동으로 번역할 수도 있습니다. 음성 텍스트 변환된 텍스트는 분석되고 번역되어 단어의 의미와 문맥을 보존합니다.",
         "description": "번역 설명"
     },
     "authorSectionTitle": {
-        "message": "제작자 소개",
-        "description": "제작자 섹션 제목"
+        "message": "저자 정보",
+        "description": "저자 섹션 제목"
     },
     "authorName": {
         "message": "Julien LS",
-        "description": "제작자 이름"
+        "description": "저자 이름"
     },
     "authorRole": {
         "message": "BabelFishAI 개발자 및 제작자",
-        "description": "제작자 역할"
+        "description": "저자 역할"
+    },
+    "addModelPlaceholder": {
+        "message": "모델 추가",
+        "description": "모델 추가 자리 표시자"
+    },
+    "addModelButton": {
+        "message": "추가",
+        "description": "모델 추가 버튼"
     }
 }

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -1,15 +1,15 @@
 {
     "extensionName": {
-        "message": "BabelFishAI by jls42.org",
+        "message": "BabelFishAI van jls42.org",
         "description": "Naam van de extensie"
     },
     "extensionDescription": {
-        "message": "Zet je stem om in tekst met AI-gestuurde transcriptie en vertaling",
+        "message": "Zet je stem om in tekst met AI-aangedreven transcriptie en vertaling",
         "description": "Beschrijving van de extensie"
     },
     "optionsTitle": {
         "message": "BabelFishAI Configuratie",
-        "description": "Titel van de optiespagina"
+        "description": "Titel van de optiepagina"
     },
     "languageSettingsTitle": {
         "message": "Interfacetaal",
@@ -17,7 +17,7 @@
     },
     "selectLanguageLabel": {
         "message": "Selecteer taal:",
-        "description": "Label voor taalselectie"
+        "description": "Label voor de taalkiezer"
     },
     "languageChanged": {
         "message": "Taal succesvol gewijzigd",
@@ -32,20 +32,20 @@
         "description": "Titel van de API-sectie"
     },
     "apiKeyPlaceholder": {
-        "message": "Je OpenAI API-sleutel (sk-...)",
+        "message": "Uw OpenAI API-sleutel (sk-...)",
         "description": "Placeholder voor API-sleutel"
     },
     "apiKeyInfo": {
-        "message": "Verkrijg je API-sleutel op",
-        "description": "Informatie over API-sleutel"
+        "message": "Verkrijg uw API-sleutel op",
+        "description": "Informatie over het verkrijgen van de API-sleutel"
     },
     "pricingInfo": {
         "message": "Meer informatie over prijzen beschikbaar op",
-        "description": "Prijsinformatie"
+        "description": "Informatie over prijzen"
     },
     "supportProject": {
         "message": "Steun het project via PayPal",
-        "description": "PayPal link tekst"
+        "description": "Tekst voor de PayPal-ondersteuningslink"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
@@ -53,11 +53,11 @@
     },
     "translationApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/chat/completions",
-        "description": "Standaard Vertaling API URL"
+        "description": "Standaard vertaal-API URL"
     },
     "displaySettingsTitle": {
         "message": "Weergave-instellingen",
-        "description": "Titel weergave-instellingen"
+        "description": "Titel van de weergave-instellingen"
     },
     "activeDisplayLabel": {
         "message": "Actief gebied (toetsenbordinvoer)",
@@ -65,14 +65,14 @@
     },
     "dialogDisplayLabel": {
         "message": "Dialoogvenster",
-        "description": "Label voor dialoogweergave"
+        "description": "Label voor weergave in dialoogvenster"
     },
     "dialogDurationLabel": {
-        "message": "Weergaveduur dialoog (seconden):",
-        "description": "Label voor dialoogduur"
+        "message": "Weergaveduur dialoogvenster (seconden):",
+        "description": "Label voor duur van dialoogvenster"
     },
     "bannerColorsLabel": {
-        "message": "Statusbannerkleuren:",
+        "message": "Kleuren van de statusbalk:",
         "description": "Label voor bannerkleuren"
     },
     "startColorLabel": {
@@ -84,8 +84,8 @@
         "description": "Label voor eindkleur"
     },
     "opacityLabel": {
-        "message": "% Doorzichtigheid",
-        "description": "Label voor doorzichtigheid"
+        "message": "% Ondoorzichtigheid",
+        "description": "Label voor ondoorzichtigheid"
     },
     "translationTitle": {
         "message": "Geïntegreerde AI-vertaling",
@@ -93,27 +93,27 @@
     },
     "enableTranslationLabel": {
         "message": "Automatische vertaling inschakelen",
-        "description": "Label voor vertaling inschakelen"
+        "description": "Label voor het inschakelen van vertaling"
     },
     "sourceLanguageLabel": {
-        "message": "Brontaal:",
+        "message": "Bron taal:",
         "description": "Label voor brontaal"
     },
     "targetLanguageLabel": {
-        "message": "Doeltaal:",
+        "message": "Doel taal:",
         "description": "Label voor doeltaal"
     },
     "expertModeTitle": {
         "message": "Expertmodus",
-        "description": "Titel expertmodus"
+        "description": "Titel van de expertmodus"
     },
     "enableExpertModeLabel": {
         "message": "Expertmodus inschakelen",
-        "description": "Label voor expertmodus inschakelen"
+        "description": "Label voor het inschakelen van de expertmodus"
     },
     "advancedConfigTitle": {
         "message": "Geavanceerde configuratie",
-        "description": "Titel geavanceerde configuratie"
+        "description": "Titel van de geavanceerde configuratie"
     },
     "translationModelLabel": {
         "message": "Vertaalmodel:",
@@ -128,39 +128,39 @@
         "description": "Label voor Whisper API URL"
     },
     "translationApiUrlLabel": {
-        "message": "Vertaling API URL:",
-        "description": "Label voor Vertaling API URL"
+        "message": "Vertaal-API URL:",
+        "description": "Label voor vertaal-API URL"
     },
     "forcedDialogDomainsLabel": {
-        "message": "Domeinen met geforceerde dialoog:",
-        "description": "Label voor geforceerde domeinen"
+        "message": "Domeinen met geforceerd dialoogvenster:",
+        "description": "Label voor geforceerde dialoogdomeinen"
     },
     "addDomainPlaceholder": {
         "message": "Voorbeeld: chat.google.com",
-        "description": "Placeholder voor domein toevoegen"
+        "description": "Placeholder voor het toevoegen van een domein"
     },
     "addDomainButton": {
         "message": "Toevoegen",
-        "description": "Knop voor domein toevoegen"
+        "description": "Knop om een domein toe te voegen"
     },
     "forcedDialogInfo": {
-        "message": "Op deze domeinen zal de transcriptie altijd in een dialoogvenster verschijnen",
-        "description": "Informatie over geforceerde domeinen"
+        "message": "Op deze domeinen verschijnt de transcriptie altijd in een dialoogvenster",
+        "description": "Informatie over geforceerde dialoogdomeinen"
     },
     "saveButton": {
         "message": "Opslaan",
-        "description": "Opslaan knop"
+        "description": "Knop Opslaan"
     },
     "userGuideTitle": {
         "message": "Gebruikershandleiding",
-        "description": "Titel gebruikershandleiding"
+        "description": "Titel van de gebruikershandleiding"
     },
     "userGuideStep1": {
         "message": "Klik op het BabelFishAI-pictogram of gebruik de sneltoets om de opname te starten",
         "description": "Stap 1 van de handleiding"
     },
     "userGuideStep2": {
-        "message": "Spreek duidelijk in je microfoon",
+        "message": "Spreek duidelijk in uw microfoon",
         "description": "Stap 2 van de handleiding"
     },
     "userGuideStep3": {
@@ -168,52 +168,52 @@
         "description": "Stap 3 van de handleiding"
     },
     "userGuideStep4": {
-        "message": "De transcriptie verschijnt volgens je geconfigureerde voorkeuren",
+        "message": "De transcriptie verschijnt volgens uw geconfigureerde voorkeuren",
         "description": "Stap 4 van de handleiding"
     },
     "userGuideStep5": {
-        "message": "Gebruik de \"Kopiëren\"-knop om de tekst naar het klembord te kopiëren",
+        "message": "Gebruik de knop \"Kopiëren\" om de tekst naar het klembord te kopiëren",
         "description": "Stap 5 van de handleiding"
     },
     "shortcutsTitle": {
         "message": "Sneltoetsen",
-        "description": "Titel sneltoetsen"
+        "description": "Titel van de sneltoetsen"
     },
     "shortcutStartStop": {
-        "message": "Om opname te starten/stoppen:",
-        "description": "Beschrijving hoofdsneltoets"
+        "message": "Om de opname te starten/stoppen:",
+        "description": "Beschrijving van de hoofdsneltoets"
     },
     "shortcutKeys": {
         "message": "Ctrl+Shift+1 (⌘+Shift+1 op Mac)",
-        "description": "Beschrijving sneltoetsen"
+        "description": "Beschrijving van de sneltoetsen"
     },
     "aiTranscriptionTitle": {
         "message": "AI-ondersteunde transcriptie",
-        "description": "Titel AI-transcriptie"
+        "description": "Titel van de transcriptiesectie"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAI gebruikt geavanceerde kunstmatige intelligentie om je stem om te zetten in tekst. Het transcriptieproces gebeurt in twee stappen.",
-        "description": "Beschrijving transcriptie"
+        "message": "BabelFishAI maakt gebruik van geavanceerde kunstmatige intelligentie om uw stem om te zetten in tekst. Het transcriptieproces vindt plaats in twee stappen.",
+        "description": "Beschrijving van de transcriptie"
     },
     "aiTranscriptionStep1": {
-        "message": "Je stem wordt opgenomen via de microfoon van je apparaat",
-        "description": "Transcriptiestap 1"
+        "message": "Uw stem wordt opgenomen via de microfoon van uw apparaat",
+        "description": "Stap 1 van de transcriptie"
     },
     "aiTranscriptionStep2": {
-        "message": "De opname wordt geanalyseerd door Whisper AI om een nauwkeurige transcriptie te produceren",
-        "description": "Transcriptiestap 2"
+        "message": "De opname wordt geanalyseerd door de Whisper AI om een nauwkeurige transcriptie te produceren",
+        "description": "Stap 2 van de transcriptie"
     },
     "aiTranslationTitle": {
         "message": "AI-ondersteunde vertaling",
-        "description": "Titel AI-vertaling"
+        "description": "Titel van de AI-vertaalsectie"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAI kan je transcripties ook automatisch vertalen met behulp van OpenAI's geavanceerde AI. De getranscribeerde tekst wordt geanalyseerd en vertaald met behoud van betekenis en context.",
-        "description": "Beschrijving vertaling"
+        "message": "BabelFishAI kan uw transcripties ook automatisch vertalen dankzij de geavanceerde AI van OpenAI. De getranscribeerde tekst wordt geanalyseerd en vertaald met behoud van de betekenis en context van uw woorden.",
+        "description": "Beschrijving van de vertaling"
     },
     "authorSectionTitle": {
         "message": "Over de auteur",
-        "description": "Titel auteursectie"
+        "description": "Titel van de auteurssectie"
     },
     "authorName": {
         "message": "Julien LS",
@@ -222,5 +222,13 @@
     "authorRole": {
         "message": "Ontwikkelaar en maker van BabelFishAI",
         "description": "Rol van de auteur"
+    },
+    "addModelPlaceholder": {
+        "message": "Model toevoegen",
+        "description": "Placeholder voor het toevoegen van een model"
+    },
+    "addModelButton": {
+        "message": "Toevoegen",
+        "description": "Knop om een model toe te voegen"
     }
 }

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -1,10 +1,10 @@
 {
     "extensionName": {
-        "message": "BabelFishAI by jls42.org",
+        "message": "BabelFishAI od jls42.org",
         "description": "Nazwa rozszerzenia"
     },
     "extensionDescription": {
-        "message": "Przekształć swój głos w tekst dzięki transkrypcji i tłumaczeniu wspomaganemu przez AI",
+        "message": "Zamień swój głos na tekst dzięki transkrypcji i tłumaczeniu opartym na sztucznej inteligencji",
         "description": "Opis rozszerzenia"
     },
     "optionsTitle": {
@@ -13,14 +13,14 @@
     },
     "languageSettingsTitle": {
         "message": "Język interfejsu",
-        "description": "Tytuł sekcji języka"
+        "description": "Tytuł sekcji językowej"
     },
     "selectLanguageLabel": {
         "message": "Wybierz język:",
-        "description": "Etykieta wyboru języka"
+        "description": "Etykieta selektora języka"
     },
     "languageChanged": {
-        "message": "Język został zmieniony",
+        "message": "Język został pomyślnie zmieniony",
         "description": "Komunikat potwierdzenia zmiany języka"
     },
     "savedMessage": {
@@ -33,46 +33,46 @@
     },
     "apiKeyPlaceholder": {
         "message": "Twój klucz API OpenAI (sk-...)",
-        "description": "Placeholder dla klucza API"
+        "description": "Symbol zastępczy klucza API"
     },
     "apiKeyInfo": {
-        "message": "Uzyskaj klucz API na",
-        "description": "Informacja o kluczu API"
+        "message": "Uzyskaj klucz API na stronie",
+        "description": "Informacje o uzyskiwaniu klucza API"
     },
     "pricingInfo": {
-        "message": "Więcej informacji o cenach dostępnych na",
+        "message": "Więcej informacji o cenach dostępnych na stronie",
         "description": "Informacje o cenach"
     },
     "supportProject": {
         "message": "Wesprzyj projekt przez PayPal",
-        "description": "Tekst linku PayPal"
+        "description": "Tekst linku do wsparcia PayPal"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
-        "description": "Domyślny URL API Whisper"
+        "description": "Domyślny adres URL interfejsu API Whisper"
     },
     "translationApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/chat/completions",
-        "description": "Domyślny URL API tłumaczenia"
+        "description": "Domyślny adres URL interfejsu API tłumaczenia"
     },
     "displaySettingsTitle": {
         "message": "Ustawienia wyświetlania",
         "description": "Tytuł ustawień wyświetlania"
     },
     "activeDisplayLabel": {
-        "message": "Obszar aktywny (wprowadzanie z klawiatury)",
-        "description": "Etykieta wyświetlania aktywnego"
+        "message": "Aktywny obszar (wprowadzanie z klawiatury)",
+        "description": "Etykieta aktywnego wyświetlania"
     },
     "dialogDisplayLabel": {
         "message": "Okno dialogowe",
         "description": "Etykieta wyświetlania okna dialogowego"
     },
     "dialogDurationLabel": {
-        "message": "Czas wyświetlania okna (sekundy):",
-        "description": "Etykieta czasu trwania okna"
+        "message": "Czas wyświetlania okna dialogowego (w sekundach):",
+        "description": "Etykieta czasu trwania okna dialogowego"
     },
     "bannerColorsLabel": {
-        "message": "Kolory banera statusu:",
+        "message": "Kolory banera stanu:",
         "description": "Etykieta kolorów banera"
     },
     "startColorLabel": {
@@ -84,8 +84,8 @@
         "description": "Etykieta koloru końcowego"
     },
     "opacityLabel": {
-        "message": "% Przezroczystości",
-        "description": "Etykieta przezroczystości"
+        "message": "% Krycie",
+        "description": "Etykieta krycia"
     },
     "translationTitle": {
         "message": "Zintegrowane tłumaczenie AI",
@@ -93,7 +93,7 @@
     },
     "enableTranslationLabel": {
         "message": "Włącz automatyczne tłumaczenie",
-        "description": "Etykieta włączenia tłumaczenia"
+        "description": "Etykieta włączania tłumaczenia"
     },
     "sourceLanguageLabel": {
         "message": "Język źródłowy:",
@@ -104,12 +104,12 @@
         "description": "Etykieta języka docelowego"
     },
     "expertModeTitle": {
-        "message": "Tryb eksperta",
-        "description": "Tytuł trybu eksperta"
+        "message": "Tryb ekspercki",
+        "description": "Tytuł trybu eksperckiego"
     },
     "enableExpertModeLabel": {
-        "message": "Włącz tryb eksperta",
-        "description": "Etykieta włączenia trybu eksperta"
+        "message": "Włącz tryb ekspercki",
+        "description": "Etykieta włączania trybu eksperckiego"
     },
     "advancedConfigTitle": {
         "message": "Konfiguracja zaawansowana",
@@ -124,28 +124,28 @@
         "description": "Etykieta modelu audio"
     },
     "whisperApiUrlLabel": {
-        "message": "URL API Whisper:",
-        "description": "Etykieta URL API Whisper"
+        "message": "Adres URL interfejsu API Whisper:",
+        "description": "Etykieta adresu URL interfejsu API Whisper"
     },
     "translationApiUrlLabel": {
-        "message": "URL API tłumaczenia:",
-        "description": "Etykieta URL API tłumaczenia"
+        "message": "Adres URL interfejsu API tłumaczenia:",
+        "description": "Etykieta adresu URL interfejsu API tłumaczenia"
     },
     "forcedDialogDomainsLabel": {
         "message": "Domeny z wymuszonym oknem dialogowym:",
-        "description": "Etykieta wymuszonych domen"
+        "description": "Etykieta domen z wymuszonym oknem dialogowym"
     },
     "addDomainPlaceholder": {
         "message": "Przykład: chat.google.com",
-        "description": "Placeholder dla dodawania domeny"
+        "description": "Symbol zastępczy dodawania domeny"
     },
     "addDomainButton": {
         "message": "Dodaj",
         "description": "Przycisk dodawania domeny"
     },
     "forcedDialogInfo": {
-        "message": "Na tych domenach transkrypcja zawsze pojawi się w oknie dialogowym",
-        "description": "Informacja o wymuszonych domenach"
+        "message": "W tych domenach transkrypcja zawsze będzie wyświetlana w oknie dialogowym",
+        "description": "Informacje o domenach z wymuszonym oknem dialogowym"
     },
     "saveButton": {
         "message": "Zapisz",
@@ -156,7 +156,7 @@
         "description": "Tytuł przewodnika użytkownika"
     },
     "userGuideStep1": {
-        "message": "Kliknij ikonę BabelFishAI lub użyj skrótu klawiszowego, aby rozpocząć nagrywanie",
+        "message": "Kliknij ikonę BabelFishAI lub użyj skrótu klawiaturowego, aby rozpocząć nagrywanie",
         "description": "Krok 1 przewodnika"
     },
     "userGuideStep2": {
@@ -168,7 +168,7 @@
         "description": "Krok 3 przewodnika"
     },
     "userGuideStep4": {
-        "message": "Transkrypcja pojawi się zgodnie z skonfigurowanymi preferencjami",
+        "message": "Transkrypcja pojawi się zgodnie z Twoimi skonfigurowanymi preferencjami",
         "description": "Krok 4 przewodnika"
     },
     "userGuideStep5": {
@@ -176,7 +176,7 @@
         "description": "Krok 5 przewodnika"
     },
     "shortcutsTitle": {
-        "message": "Skróty klawiszowe",
+        "message": "Skróty klawiaturowe",
         "description": "Tytuł skrótów"
     },
     "shortcutStartStop": {
@@ -184,31 +184,31 @@
         "description": "Opis głównego skrótu"
     },
     "shortcutKeys": {
-        "message": "Ctrl+Shift+1 (⌘+Shift+1 na Mac)",
+        "message": "Ctrl+Shift+1 (⌘+Shift+1 na Macu)",
         "description": "Opis klawiszy skrótu"
     },
     "aiTranscriptionTitle": {
-        "message": "Transkrypcja wspomagana AI",
-        "description": "Tytuł transkrypcji AI"
+        "message": "Transkrypcja wspomagana przez AI",
+        "description": "Tytuł sekcji transkrypcji"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAI wykorzystuje najnowocześniejszą sztuczną inteligencję do przekształcania głosu w tekst. Proces transkrypcji odbywa się w dwóch krokach.",
+        "message": "BabelFishAI wykorzystuje najnowocześniejszą sztuczną inteligencję do transkrypcji Twojego głosu na tekst. Proces transkrypcji odbywa się w dwóch etapach.",
         "description": "Opis transkrypcji"
     },
     "aiTranscriptionStep1": {
-        "message": "Twój głos jest nagrywany przez mikrofon urządzenia",
+        "message": "Twój głos jest nagrywany przez mikrofon Twojego urządzenia",
         "description": "Krok 1 transkrypcji"
     },
     "aiTranscriptionStep2": {
-        "message": "Nagranie jest analizowane przez Whisper AI w celu utworzenia dokładnej transkrypcji",
+        "message": "Nagranie jest analizowane przez AI Whisper w celu uzyskania dokładnej transkrypcji",
         "description": "Krok 2 transkrypcji"
     },
     "aiTranslationTitle": {
-        "message": "Tłumaczenie wspomagane AI",
-        "description": "Tytuł tłumaczenia AI"
+        "message": "Tłumaczenie wspomagane przez AI",
+        "description": "Tytuł sekcji tłumaczenia AI"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAI może również automatycznie tłumaczyć transkrypcje przy użyciu zaawansowanej AI OpenAI. Tekst transkrypcji jest analizowany i tłumaczony z zachowaniem znaczenia i kontekstu wypowiedzi.",
+        "message": "BabelFishAI może również automatycznie tłumaczyć Twoje transkrypcje dzięki zaawansowanej sztucznej inteligencji OpenAI. Transkrybowany tekst jest analizowany i tłumaczony z zachowaniem znaczenia i kontekstu Twoich słów.",
         "description": "Opis tłumaczenia"
     },
     "authorSectionTitle": {
@@ -220,7 +220,15 @@
         "description": "Imię autora"
     },
     "authorRole": {
-        "message": "Programista i twórca BabelFishAI",
+        "message": "Deweloper i twórca BabelFishAI",
         "description": "Rola autora"
+    },
+    "addModelPlaceholder": {
+        "message": "Dodaj model",
+        "description": "Symbol zastępczy dodawania modelu"
+    },
+    "addModelButton": {
+        "message": "Dodaj",
+        "description": "Przycisk dodawania modelu"
     }
 }

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -1,10 +1,10 @@
 {
     "extensionName": {
-        "message": "BabelFishAI by jls42.org",
+        "message": "BabelFishAI por jls42.org",
         "description": "Nome da extensão"
     },
     "extensionDescription": {
-        "message": "Transforme sua voz em texto com transcrição e tradução alimentada por IA",
+        "message": "Transforme sua voz em texto com transcrição e tradução com tecnologia de IA",
         "description": "Descrição da extensão"
     },
     "optionsTitle": {
@@ -17,7 +17,7 @@
     },
     "selectLanguageLabel": {
         "message": "Selecione o idioma:",
-        "description": "Rótulo do seletor de idioma"
+        "description": "Rótulo para o seletor de idioma"
     },
     "languageChanged": {
         "message": "Idioma alterado com sucesso",
@@ -29,23 +29,23 @@
     },
     "apiConfigTitle": {
         "message": "Configuração da API",
-        "description": "Título da seção API"
+        "description": "Título da seção da API"
     },
     "apiKeyPlaceholder": {
-        "message": "Sua chave API OpenAI (sk-...)",
-        "description": "Placeholder para a chave API"
+        "message": "Sua chave de API OpenAI (sk-...)",
+        "description": "Espaço reservado para a chave da API"
     },
     "apiKeyInfo": {
-        "message": "Obtenha sua chave API em",
-        "description": "Informação sobre obtenção da chave API"
+        "message": "Obtenha sua chave de API em",
+        "description": "Informações sobre como obter a chave da API"
     },
     "pricingInfo": {
         "message": "Mais informações sobre preços disponíveis em",
-        "description": "Informação sobre preços"
+        "description": "Informações sobre preços"
     },
     "supportProject": {
-        "message": "Apoiar o projeto via PayPal",
-        "description": "Texto do link PayPal"
+        "message": "Apoie o projeto via PayPal",
+        "description": "Texto para o link de suporte do PayPal"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
@@ -56,60 +56,60 @@
         "description": "URL padrão da API de tradução"
     },
     "displaySettingsTitle": {
-        "message": "Configurações de exibição",
+        "message": "Configurações de Exibição",
         "description": "Título das configurações de exibição"
     },
     "activeDisplayLabel": {
         "message": "Área ativa (entrada de teclado)",
-        "description": "Rótulo de exibição ativa"
+        "description": "Rótulo para exibição ativa"
     },
     "dialogDisplayLabel": {
         "message": "Caixa de diálogo",
-        "description": "Rótulo de exibição de diálogo"
+        "description": "Rótulo para exibição em caixa de diálogo"
     },
     "dialogDurationLabel": {
-        "message": "Duração de exibição da caixa (segundos):",
-        "description": "Rótulo de duração do diálogo"
+        "message": "Duração da exibição da caixa de diálogo (segundos):",
+        "description": "Rótulo para a duração da caixa de diálogo"
     },
     "bannerColorsLabel": {
         "message": "Cores do banner de status:",
-        "description": "Rótulo de cores do banner"
+        "description": "Rótulo para as cores do banner"
     },
     "startColorLabel": {
         "message": "Cor inicial:",
-        "description": "Rótulo de cor inicial"
+        "description": "Rótulo para a cor inicial"
     },
     "endColorLabel": {
         "message": "Cor final:",
-        "description": "Rótulo de cor final"
+        "description": "Rótulo para a cor final"
     },
     "opacityLabel": {
-        "message": "% Opacidade",
-        "description": "Rótulo de opacidade"
+        "message": "% de opacidade",
+        "description": "Rótulo para a opacidade"
     },
     "translationTitle": {
-        "message": "Tradução IA Integrada",
+        "message": "Tradução Integrada com IA",
         "description": "Título da seção de tradução"
     },
     "enableTranslationLabel": {
-        "message": "Ativar tradução automática",
-        "description": "Rótulo para ativar tradução"
+        "message": "Habilitar tradução automática",
+        "description": "Rótulo para habilitar a tradução"
     },
     "sourceLanguageLabel": {
         "message": "Idioma de origem:",
-        "description": "Rótulo de idioma de origem"
+        "description": "Rótulo para o idioma de origem"
     },
     "targetLanguageLabel": {
         "message": "Idioma de destino:",
-        "description": "Rótulo de idioma de destino"
+        "description": "Rótulo para o idioma de destino"
     },
     "expertModeTitle": {
-        "message": "Modo Especialista",
-        "description": "Título do modo especialista"
+        "message": "Modo Expert",
+        "description": "Título do modo expert"
     },
     "enableExpertModeLabel": {
-        "message": "Ativar modo especialista",
-        "description": "Rótulo para ativar modo especialista"
+        "message": "Habilitar modo expert",
+        "description": "Rótulo para habilitar o modo expert"
     },
     "advancedConfigTitle": {
         "message": "Configuração Avançada",
@@ -117,35 +117,35 @@
     },
     "translationModelLabel": {
         "message": "Modelo de tradução:",
-        "description": "Rótulo do modelo de tradução"
+        "description": "Rótulo para o modelo de tradução"
     },
     "audioModelLabel": {
         "message": "Modelo de áudio:",
-        "description": "Etiqueta para o modelo de áudio"
+        "description": "Rótulo para o modelo de áudio"
     },
     "whisperApiUrlLabel": {
         "message": "URL da API Whisper:",
-        "description": "Rótulo da URL da API Whisper"
+        "description": "Rótulo para a URL da API Whisper"
     },
     "translationApiUrlLabel": {
         "message": "URL da API de tradução:",
-        "description": "Rótulo da URL da API de tradução"
+        "description": "Rótulo para a URL da API de tradução"
     },
     "forcedDialogDomainsLabel": {
-        "message": "Domínios com diálogo forçado:",
-        "description": "Rótulo de domínios forçados"
+        "message": "Domínios com caixa de diálogo forçada:",
+        "description": "Rótulo para os domínios forçados"
     },
     "addDomainPlaceholder": {
         "message": "Exemplo: chat.google.com",
-        "description": "Placeholder para adicionar domínio"
+        "description": "Espaço reservado para adicionar domínio"
     },
     "addDomainButton": {
         "message": "Adicionar",
-        "description": "Botão para adicionar domínio"
+        "description": "Botão para adicionar um domínio"
     },
     "forcedDialogInfo": {
-        "message": "Nestes domínios, a transcrição sempre aparecerá em uma caixa de diálogo",
-        "description": "Informação sobre domínios forçados"
+        "message": "Nesses domínios, a transcrição sempre aparecerá em uma caixa de diálogo",
+        "description": "Informações sobre os domínios forçados"
     },
     "saveButton": {
         "message": "Salvar",
@@ -156,11 +156,11 @@
         "description": "Título do guia do usuário"
     },
     "userGuideStep1": {
-        "message": "Clique no ícone BabelFishAI ou use o atalho de teclado para iniciar a gravação",
+        "message": "Clique no ícone do BabelFishAI ou use o atalho do teclado para iniciar a gravação",
         "description": "Passo 1 do guia"
     },
     "userGuideStep2": {
-        "message": "Fale claramente em seu microfone",
+        "message": "Fale claramente no seu microfone",
         "description": "Passo 2 do guia"
     },
     "userGuideStep3": {
@@ -189,10 +189,10 @@
     },
     "aiTranscriptionTitle": {
         "message": "Transcrição Assistida por IA",
-        "description": "Título da transcrição IA"
+        "description": "Título da seção de transcrição"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAI usa inteligência artificial de ponta para transcrever sua voz em texto. O processo de transcrição acontece em duas etapas.",
+        "message": "O BabelFishAI usa inteligência artificial de ponta para transcrever sua voz em texto. O processo de transcrição ocorre em duas etapas.",
         "description": "Descrição da transcrição"
     },
     "aiTranscriptionStep1": {
@@ -205,15 +205,15 @@
     },
     "aiTranslationTitle": {
         "message": "Tradução Assistida por IA",
-        "description": "Título da tradução IA"
+        "description": "Título da seção de tradução IA"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAI também pode traduzir automaticamente suas transcrições usando a IA avançada da OpenAI. O texto transcrito é analisado e traduzido preservando o significado e contexto da sua fala.",
+        "message": "O BabelFishAI também pode traduzir automaticamente suas transcrições graças à IA avançada da OpenAI. O texto transcrito é analisado e traduzido preservando o significado e o contexto de suas palavras.",
         "description": "Descrição da tradução"
     },
     "authorSectionTitle": {
         "message": "Sobre o Autor",
-        "description": "Título da seção autor"
+        "description": "Título da seção do autor"
     },
     "authorName": {
         "message": "Julien LS",
@@ -222,5 +222,13 @@
     "authorRole": {
         "message": "Desenvolvedor e criador do BabelFishAI",
         "description": "Função do autor"
+    },
+    "addModelPlaceholder": {
+        "message": "Adicionar um modelo",
+        "description": "Espaço reservado para adicionar um modelo"
+    },
+    "addModelButton": {
+        "message": "Adicionar",
+        "description": "Botão para adicionar um modelo"
     }
 }

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -1,10 +1,10 @@
 {
     "extensionName": {
-        "message": "BabelFishAI by jls42.org",
+        "message": "BabelFishAI de jls42.org",
         "description": "Numele extensiei"
     },
     "extensionDescription": {
-        "message": "Transformă vocea în text cu transcriere și traducere bazată pe AI",
+        "message": "Transformă-ți vocea în text cu transcriere și traducere bazate pe IA",
         "description": "Descrierea extensiei"
     },
     "optionsTitle": {
@@ -16,44 +16,44 @@
         "description": "Titlul secțiunii de limbă"
     },
     "selectLanguageLabel": {
-        "message": "Selectează limba:",
-        "description": "Eticheta selectorului de limbă"
+        "message": "Selectați limba:",
+        "description": "Etichetă pentru selectorul de limbă"
     },
     "languageChanged": {
         "message": "Limba a fost schimbată cu succes",
-        "description": "Mesaj de confirmare pentru schimbarea limbii"
+        "description": "Mesaj de confirmare a schimbării limbii"
     },
     "savedMessage": {
         "message": "Opțiuni salvate!",
-        "description": "Mesaj de confirmare pentru salvare"
+        "description": "Mesaj de confirmare a salvării"
     },
     "apiConfigTitle": {
         "message": "Configurare API",
         "description": "Titlul secțiunii API"
     },
     "apiKeyPlaceholder": {
-        "message": "Cheia ta API OpenAI (sk-...)",
+        "message": "Cheia dvs. API OpenAI (sk-...)",
         "description": "Placeholder pentru cheia API"
     },
     "apiKeyInfo": {
-        "message": "Obține cheia API de la",
-        "description": "Informații despre cheia API"
+        "message": "Obțineți cheia API la",
+        "description": "Informații despre obținerea cheii API"
     },
     "pricingInfo": {
         "message": "Mai multe informații despre prețuri disponibile la",
         "description": "Informații despre prețuri"
     },
     "supportProject": {
-        "message": "Susține proiectul prin PayPal",
-        "description": "Text link PayPal"
+        "message": "Sprijiniți proiectul prin PayPal",
+        "description": "Text pentru linkul de suport PayPal"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
-        "description": "URL implicit API Whisper"
+        "description": "URL-ul implicit al API-ului Whisper"
     },
     "translationApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/chat/completions",
-        "description": "URL implicit API traducere"
+        "description": "URL-ul implicit al API-ului de traducere"
     },
     "displaySettingsTitle": {
         "message": "Setări de afișare",
@@ -61,15 +61,15 @@
     },
     "activeDisplayLabel": {
         "message": "Zonă activă (introducere de la tastatură)",
-        "description": "Etichetă pentru afișare activă"
+        "description": "Etichetă pentru afișarea activă"
     },
     "dialogDisplayLabel": {
-        "message": "Fereastră de dialog",
-        "description": "Etichetă pentru afișare dialog"
+        "message": "Casetă de dialog",
+        "description": "Etichetă pentru afișarea în caseta de dialog"
     },
     "dialogDurationLabel": {
-        "message": "Durata de afișare a ferestrei (secunde):",
-        "description": "Etichetă pentru durata dialogului"
+        "message": "Durata de afișare a casetei de dialog (secunde):",
+        "description": "Etichetă pentru durata casetei de dialog"
     },
     "bannerColorsLabel": {
         "message": "Culorile bannerului de stare:",
@@ -88,12 +88,12 @@
         "description": "Etichetă pentru opacitate"
     },
     "translationTitle": {
-        "message": "Traducere AI integrată",
+        "message": "Traducere integrată cu IA",
         "description": "Titlul secțiunii de traducere"
     },
     "enableTranslationLabel": {
-        "message": "Activează traducerea automată",
-        "description": "Etichetă pentru activare traducere"
+        "message": "Activați traducerea automată",
+        "description": "Etichetă pentru activarea traducerii"
     },
     "sourceLanguageLabel": {
         "message": "Limba sursă:",
@@ -104,16 +104,16 @@
         "description": "Etichetă pentru limba țintă"
     },
     "expertModeTitle": {
-        "message": "Mod expert",
+        "message": "Mod Expert",
         "description": "Titlul modului expert"
     },
     "enableExpertModeLabel": {
-        "message": "Activează modul expert",
-        "description": "Etichetă pentru activare mod expert"
+        "message": "Activați modul expert",
+        "description": "Etichetă pentru activarea modului expert"
     },
     "advancedConfigTitle": {
         "message": "Configurare avansată",
-        "description": "Titlul configurării avansate"
+        "description": "Titlul configurației avansate"
     },
     "translationModelLabel": {
         "message": "Model de traducere:",
@@ -124,103 +124,111 @@
         "description": "Etichetă pentru modelul audio"
     },
     "whisperApiUrlLabel": {
-        "message": "URL API Whisper:",
-        "description": "Etichetă pentru URL API Whisper"
+        "message": "URL-ul API-ului Whisper:",
+        "description": "Etichetă pentru URL-ul API-ului Whisper"
     },
     "translationApiUrlLabel": {
-        "message": "URL API traducere:",
-        "description": "Etichetă pentru URL API traducere"
+        "message": "URL-ul API-ului de traducere:",
+        "description": "Etichetă pentru URL-ul API-ului de traducere"
     },
     "forcedDialogDomainsLabel": {
-        "message": "Domenii cu dialog forțat:",
-        "description": "Etichetă pentru domenii forțate"
+        "message": "Domenii cu casetă de dialog forțată:",
+        "description": "Etichetă pentru domeniile cu casetă de dialog forțată"
     },
     "addDomainPlaceholder": {
         "message": "Exemplu: chat.google.com",
-        "description": "Placeholder pentru adăugare domeniu"
+        "description": "Placeholder pentru adăugarea unui domeniu"
     },
     "addDomainButton": {
-        "message": "Adaugă",
-        "description": "Buton pentru adăugare domeniu"
+        "message": "Adăugați",
+        "description": "Buton pentru adăugarea unui domeniu"
     },
     "forcedDialogInfo": {
-        "message": "Pe aceste domenii, transcrierea va apărea întotdeauna într-o fereastră de dialog",
-        "description": "Informații despre domeniile forțate"
+        "message": "Pe aceste domenii, transcrierea va apărea întotdeauna într-o casetă de dialog",
+        "description": "Informații despre domeniile cu casetă de dialog forțată"
     },
     "saveButton": {
-        "message": "Salvează",
-        "description": "Buton de salvare"
+        "message": "Salvați",
+        "description": "Butonul de salvare"
     },
     "userGuideTitle": {
         "message": "Ghid de utilizare",
         "description": "Titlul ghidului de utilizare"
     },
     "userGuideStep1": {
-        "message": "Click pe iconița BabelFishAI sau folosește scurtătura de la tastatură pentru a începe înregistrarea",
-        "description": "Pasul 1 din ghid"
+        "message": "Faceți clic pe pictograma BabelFishAI sau utilizați comanda rapidă de la tastatură pentru a începe înregistrarea",
+        "description": "Pasul 1 al ghidului"
     },
     "userGuideStep2": {
-        "message": "Vorbește clar în microfon",
-        "description": "Pasul 2 din ghid"
+        "message": "Vorbiți clar în microfon",
+        "description": "Pasul 2 al ghidului"
     },
     "userGuideStep3": {
-        "message": "Click din nou sau folosește scurtătura pentru a opri înregistrarea",
-        "description": "Pasul 3 din ghid"
+        "message": "Faceți clic din nou sau utilizați comanda rapidă pentru a opri înregistrarea",
+        "description": "Pasul 3 al ghidului"
     },
     "userGuideStep4": {
-        "message": "Transcrierea va apărea conform preferințelor configurate",
-        "description": "Pasul 4 din ghid"
+        "message": "Transcripția va apărea în funcție de preferințele dvs. configurate",
+        "description": "Pasul 4 al ghidului"
     },
     "userGuideStep5": {
-        "message": "Folosește butonul \"Copiază\" pentru a copia textul în clipboard",
-        "description": "Pasul 5 din ghid"
+        "message": "Utilizați butonul \"Copiați\" pentru a copia textul în clipboard",
+        "description": "Pasul 5 al ghidului"
     },
     "shortcutsTitle": {
-        "message": "Scurtături de tastatură",
-        "description": "Titlul scurtăturilor"
+        "message": "Comenzi rapide de la tastatură",
+        "description": "Titlul comenzilor rapide"
     },
     "shortcutStartStop": {
-        "message": "Pentru a începe/opri înregistrarea:",
-        "description": "Descriere scurtătură principală"
+        "message": "Pentru a porni/opri înregistrarea:",
+        "description": "Descrierea comenzii rapide principale"
     },
     "shortcutKeys": {
         "message": "Ctrl+Shift+1 (⌘+Shift+1 pe Mac)",
-        "description": "Descriere taste scurtătură"
+        "description": "Descrierea tastelor de comandă rapidă"
     },
     "aiTranscriptionTitle": {
-        "message": "Transcriere asistată de AI",
-        "description": "Titlul transcrierii AI"
+        "message": "Transcriere asistată de IA",
+        "description": "Titlul secțiunii de transcriere"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAI folosește inteligență artificială de ultimă generație pentru a-ți transforma vocea în text. Procesul de transcriere are loc în doi pași.",
-        "description": "Descriere transcriere"
+        "message": "BabelFishAI utilizează inteligența artificială de ultimă generație pentru a transcrie vocea dvs. în text. Procesul de transcriere are loc în două etape.",
+        "description": "Descrierea transcrierii"
     },
     "aiTranscriptionStep1": {
-        "message": "Vocea ta este înregistrată prin microfonul dispozitivului",
-        "description": "Pasul 1 transcriere"
+        "message": "Vocea dvs. este înregistrată prin intermediul microfonului dispozitivului dvs.",
+        "description": "Pasul 1 al transcrierii"
     },
     "aiTranscriptionStep2": {
-        "message": "Înregistrarea este analizată de Whisper AI pentru a produce o transcriere precisă",
-        "description": "Pasul 2 transcriere"
+        "message": "Înregistrarea este analizată de IA Whisper pentru a produce o transcriere precisă",
+        "description": "Pasul 2 al transcrierii"
     },
     "aiTranslationTitle": {
-        "message": "Traducere asistată de AI",
-        "description": "Titlul traducerii AI"
+        "message": "Traducere asistată de IA",
+        "description": "Titlul secțiunii de traducere IA"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAI poate traduce automat transcrierile tale folosind AI-ul avansat OpenAI. Textul transcris este analizat și tradus păstrând sensul și contextul vorbirii tale.",
-        "description": "Descriere traducere"
+        "message": "BabelFishAI poate, de asemenea, să traducă automat transcrierile dvs. datorită IA avansată de la OpenAI. Textul transcris este analizat și tradus păstrând sensul și contextul cuvintelor dvs.",
+        "description": "Descrierea traducerii"
     },
     "authorSectionTitle": {
         "message": "Despre autor",
-        "description": "Titlul secțiunii despre autor"
+        "description": "Titlul secțiunii autorului"
     },
     "authorName": {
         "message": "Julien LS",
         "description": "Numele autorului"
     },
     "authorRole": {
-        "message": "Dezvoltator și creator BabelFishAI",
+        "message": "Dezvoltator și creator al BabelFishAI",
         "description": "Rolul autorului"
+    },
+    "addModelPlaceholder": {
+        "message": "Adăugați un model",
+        "description": "Placeholder pentru adăugarea unui model"
+    },
+    "addModelButton": {
+        "message": "Adăugați",
+        "description": "Buton pentru adăugarea unui model"
     }
 }

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -1,19 +1,19 @@
 {
     "extensionName": {
-        "message": "BabelFishAI by jls42.org",
+        "message": "BabelFishAI av jls42.org",
         "description": "Tilläggets namn"
     },
     "extensionDescription": {
-        "message": "Omvandla din röst till text med AI-driven transkription och översättning",
+        "message": "Förvandla din röst till text med AI-driven transkription och översättning",
         "description": "Tilläggets beskrivning"
     },
     "optionsTitle": {
-        "message": "BabelFishAI Konfiguration",
-        "description": "Titel för inställningssidan"
+        "message": "BabelFishAI-konfiguration",
+        "description": "Titel på alternativsidan"
     },
     "languageSettingsTitle": {
         "message": "Gränssnittsspråk",
-        "description": "Titel för språkavsnittet"
+        "description": "Titel på språksektionen"
     },
     "selectLanguageLabel": {
         "message": "Välj språk:",
@@ -24,28 +24,28 @@
         "description": "Bekräftelsemeddelande för språkändring"
     },
     "savedMessage": {
-        "message": "Inställningar sparade!",
+        "message": "Alternativen har sparats!",
         "description": "Bekräftelsemeddelande för sparande"
     },
     "apiConfigTitle": {
         "message": "API-konfiguration",
-        "description": "Titel för API-avsnittet"
+        "description": "Titel på API-sektionen"
     },
     "apiKeyPlaceholder": {
         "message": "Din OpenAI API-nyckel (sk-...)",
         "description": "Platshållare för API-nyckel"
     },
     "apiKeyInfo": {
-        "message": "Få din API-nyckel på",
-        "description": "Information om API-nyckel"
+        "message": "Hämta din API-nyckel på",
+        "description": "Information om att hämta API-nyckeln"
     },
     "pricingInfo": {
-        "message": "Mer prisinformation finns på",
-        "description": "Prisinformation"
+        "message": "Mer information om prissättning finns på",
+        "description": "Information om prissättning"
     },
     "supportProject": {
         "message": "Stöd projektet via PayPal",
-        "description": "PayPal-länktext"
+        "description": "Text för PayPal-supportlänk"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
@@ -57,7 +57,7 @@
     },
     "displaySettingsTitle": {
         "message": "Visningsinställningar",
-        "description": "Titel för visningsinställningar"
+        "description": "Titel på visningsinställningar"
     },
     "activeDisplayLabel": {
         "message": "Aktivt område (tangentbordsinmatning)",
@@ -65,14 +65,14 @@
     },
     "dialogDisplayLabel": {
         "message": "Dialogruta",
-        "description": "Etikett för dialogvisning"
+        "description": "Etikett för dialogrutavisning"
     },
     "dialogDurationLabel": {
-        "message": "Visningstid för dialog (sekunder):",
-        "description": "Etikett för dialogtid"
+        "message": "Visningstid för dialogrutan (sekunder):",
+        "description": "Etikett för dialogrutans varaktighet"
     },
     "bannerColorsLabel": {
-        "message": "Statusbannerfärger:",
+        "message": "Färger på statusfältet:",
         "description": "Etikett för bannerfärger"
     },
     "startColorLabel": {
@@ -89,7 +89,7 @@
     },
     "translationTitle": {
         "message": "Integrerad AI-översättning",
-        "description": "Titel för översättningsavsnittet"
+        "description": "Titel på översättningssektionen"
     },
     "enableTranslationLabel": {
         "message": "Aktivera automatisk översättning",
@@ -105,7 +105,7 @@
     },
     "expertModeTitle": {
         "message": "Expertläge",
-        "description": "Titel för expertläge"
+        "description": "Titel på expertläge"
     },
     "enableExpertModeLabel": {
         "message": "Aktivera expertläge",
@@ -113,7 +113,7 @@
     },
     "advancedConfigTitle": {
         "message": "Avancerad konfiguration",
-        "description": "Titel för avancerad konfiguration"
+        "description": "Titel på avancerad konfiguration"
     },
     "translationModelLabel": {
         "message": "Översättningsmodell:",
@@ -132,8 +132,8 @@
         "description": "Etikett för översättnings-API URL"
     },
     "forcedDialogDomainsLabel": {
-        "message": "Domäner med tvingad dialog:",
-        "description": "Etikett för tvingade domäner"
+        "message": "Domäner med tvingad dialogruta:",
+        "description": "Etikett för tvingade dialogdomäner"
     },
     "addDomainPlaceholder": {
         "message": "Exempel: chat.google.com",
@@ -141,22 +141,22 @@
     },
     "addDomainButton": {
         "message": "Lägg till",
-        "description": "Knapp för att lägga till domän"
+        "description": "Knapp för att lägga till en domän"
     },
     "forcedDialogInfo": {
         "message": "På dessa domäner kommer transkriptionen alltid att visas i en dialogruta",
-        "description": "Information om tvingade domäner"
+        "description": "Information om tvingade dialogdomäner"
     },
     "saveButton": {
         "message": "Spara",
         "description": "Spara-knapp"
     },
     "userGuideTitle": {
-        "message": "Användarguide",
-        "description": "Titel för användarguide"
+        "message": "Användarhandbok",
+        "description": "Titel på användarhandboken"
     },
     "userGuideStep1": {
-        "message": "Klicka på BabelFishAI-ikonen eller använd tangentbordsgenvägen för att starta inspelning",
+        "message": "Klicka på BabelFishAI-ikonen eller använd kortkommandot för att starta inspelningen",
         "description": "Steg 1 i guiden"
     },
     "userGuideStep2": {
@@ -164,7 +164,7 @@
         "description": "Steg 2 i guiden"
     },
     "userGuideStep3": {
-        "message": "Klicka igen eller använd genvägen för att stoppa inspelningen",
+        "message": "Klicka igen eller använd kortkommandot för att stoppa inspelningen",
         "description": "Steg 3 i guiden"
     },
     "userGuideStep4": {
@@ -176,44 +176,44 @@
         "description": "Steg 5 i guiden"
     },
     "shortcutsTitle": {
-        "message": "Tangentbordsgenvägar",
-        "description": "Titel för genvägar"
+        "message": "Kortkommandon",
+        "description": "Titel på kortkommandon"
     },
     "shortcutStartStop": {
-        "message": "För att starta/stoppa inspelning:",
-        "description": "Beskrivning av huvudgenväg"
+        "message": "För att starta/stoppa inspelningen:",
+        "description": "Beskrivning av huvudkortkommandot"
     },
     "shortcutKeys": {
         "message": "Ctrl+Shift+1 (⌘+Shift+1 på Mac)",
-        "description": "Beskrivning av genvägstangenter"
+        "description": "Beskrivning av kortkommandotangenterna"
     },
     "aiTranscriptionTitle": {
         "message": "AI-assisterad transkription",
-        "description": "Titel för AI-transkription"
+        "description": "Titel på transkriptionssektionen"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAI använder toppmodern artificiell intelligens för att omvandla din röst till text. Transkriptionsprocessen sker i två steg.",
+        "message": "BabelFishAI använder banbrytande artificiell intelligens för att transkribera din röst till text. Transkriptionsprocessen sker i två steg.",
         "description": "Beskrivning av transkription"
     },
     "aiTranscriptionStep1": {
         "message": "Din röst spelas in via enhetens mikrofon",
-        "description": "Transkriptionssteg 1"
+        "description": "Steg 1 av transkriptionen"
     },
     "aiTranscriptionStep2": {
-        "message": "Inspelningen analyseras av Whisper AI för att producera en exakt transkription",
-        "description": "Transkriptionssteg 2"
+        "message": "Inspelningen analyseras av Whisper AI för att producera en korrekt transkription",
+        "description": "Steg 2 av transkriptionen"
     },
     "aiTranslationTitle": {
         "message": "AI-assisterad översättning",
-        "description": "Titel för AI-översättning"
+        "description": "Titel på AI-översättningssektionen"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAI kan också automatiskt översätta dina transkriptioner med OpenAIs avancerade AI. Den transkriberade texten analyseras och översätts samtidigt som betydelse och sammanhang bevaras.",
+        "message": "BabelFishAI kan också automatiskt översätta dina transkriptioner tack vare OpenAIs avancerade AI. Den transkriberade texten analyseras och översätts samtidigt som betydelsen och sammanhanget i dina ord bevaras.",
         "description": "Beskrivning av översättning"
     },
     "authorSectionTitle": {
         "message": "Om författaren",
-        "description": "Titel för författaravsnittet"
+        "description": "Titel på författarsektionen"
     },
     "authorName": {
         "message": "Julien LS",
@@ -222,5 +222,13 @@
     "authorRole": {
         "message": "Utvecklare och skapare av BabelFishAI",
         "description": "Författarens roll"
+    },
+    "addModelPlaceholder": {
+        "message": "Lägg till en modell",
+        "description": "Platshållare för att lägga till en modell"
+    },
+    "addModelButton": {
+        "message": "Lägg till",
+        "description": "Knapp för att lägga till en modell"
     }
 }

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -1,14 +1,14 @@
 {
     "extensionName": {
-        "message": "BabelFishAI by jls42.org",
+        "message": "BabelFishAI 由 jls42.org 开发",
         "description": "扩展名称"
     },
     "extensionDescription": {
-        "message": "使用AI驱动的转录和翻译将语音转换为文本",
+        "message": "通过人工智能驱动的转录和翻译将您的声音转换为文本",
         "description": "扩展描述"
     },
     "optionsTitle": {
-        "message": "BabelFishAI 设置",
+        "message": "BabelFishAI 配置",
         "description": "选项页面标题"
     },
     "languageSettingsTitle": {
@@ -20,47 +20,47 @@
         "description": "语言选择器标签"
     },
     "languageChanged": {
-        "message": "语言已更改",
+        "message": "语言更改成功",
         "description": "语言更改确认消息"
     },
     "savedMessage": {
-        "message": "已保存！",
+        "message": "选项已保存！",
         "description": "保存确认消息"
     },
     "apiConfigTitle": {
-        "message": "API 设置",
-        "description": "API部分标题"
+        "message": "API 配置",
+        "description": "API 部分标题"
     },
     "apiKeyPlaceholder": {
-        "message": "OpenAI API密钥 (sk-...)",
-        "description": "API密钥占位符"
+        "message": "您的 OpenAI API 密钥 (sk-...)",
+        "description": "API 密钥占位符"
     },
     "apiKeyInfo": {
-        "message": "获取API密钥：",
-        "description": "获取API密钥信息"
+        "message": "获取您的 API 密钥：",
+        "description": "获取 API 密钥的信息"
     },
     "pricingInfo": {
-        "message": "查看价格详情：",
-        "description": "价格信息"
+        "message": "有关定价的更多信息，请访问",
+        "description": "定价信息"
     },
     "supportProject": {
-        "message": "通过PayPal支持项目",
-        "description": "PayPal支持链接"
+        "message": "通过 PayPal 支持项目",
+        "description": "PayPal 支持链接文本"
     },
     "whisperApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/audio/transcriptions",
-        "description": "Whisper API URL"
+        "description": "默认 Whisper API URL"
     },
     "translationApiUrlPlaceholder": {
         "message": "https://api.openai.com/v1/chat/completions",
-        "description": "翻译API URL"
+        "description": "默认翻译 API URL"
     },
     "displaySettingsTitle": {
         "message": "显示设置",
         "description": "显示设置标题"
     },
     "activeDisplayLabel": {
-        "message": "活动区域",
+        "message": "活动区域（键盘输入）",
         "description": "活动显示标签"
     },
     "dialogDisplayLabel": {
@@ -68,12 +68,12 @@
         "description": "对话框显示标签"
     },
     "dialogDurationLabel": {
-        "message": "显示时长（秒）：",
-        "description": "对话框时长标签"
+        "message": "对话框显示持续时间（秒）：",
+        "description": "对话框持续时间标签"
     },
     "bannerColorsLabel": {
-        "message": "状态栏颜色：",
-        "description": "状态栏颜色标签"
+        "message": "状态横幅颜色：",
+        "description": "横幅颜色标签"
     },
     "startColorLabel": {
         "message": "开始颜色：",
@@ -84,12 +84,12 @@
         "description": "结束颜色标签"
     },
     "opacityLabel": {
-        "message": "不透明度 %",
+        "message": "% 不透明度",
         "description": "不透明度标签"
     },
     "translationTitle": {
-        "message": "AI翻译",
-        "description": "翻译标题"
+        "message": "集成人工智能翻译",
+        "description": "翻译部分标题"
     },
     "enableTranslationLabel": {
         "message": "启用自动翻译",
@@ -112,8 +112,8 @@
         "description": "启用专家模式标签"
     },
     "advancedConfigTitle": {
-        "message": "高级设置",
-        "description": "高级设置标题"
+        "message": "高级配置",
+        "description": "高级配置标题"
     },
     "translationModelLabel": {
         "message": "翻译模型：",
@@ -124,103 +124,111 @@
         "description": "音频模型标签"
     },
     "whisperApiUrlLabel": {
-        "message": "Whisper API地址：",
-        "description": "Whisper API地址标签"
+        "message": "Whisper API URL：",
+        "description": "Whisper API URL 标签"
     },
     "translationApiUrlLabel": {
-        "message": "翻译API地址：",
-        "description": "翻译API地址标签"
+        "message": "翻译 API URL：",
+        "description": "翻译 API URL 标签"
     },
     "forcedDialogDomainsLabel": {
-        "message": "强制对话框域名：",
-        "description": "强制对话框域名标签"
+        "message": "强制对话框域：",
+        "description": "强制对话框域标签"
     },
     "addDomainPlaceholder": {
         "message": "示例：chat.google.com",
-        "description": "添加域名占位符"
+        "description": "添加域占位符"
     },
     "addDomainButton": {
         "message": "添加",
-        "description": "添加按钮"
+        "description": "添加域按钮"
     },
     "forcedDialogInfo": {
-        "message": "在这些域名上将始终使用对话框显示",
-        "description": "强制对话框说明"
+        "message": "在这些域上，转录将始终显示在对话框中",
+        "description": "强制对话框域信息"
     },
     "saveButton": {
         "message": "保存",
         "description": "保存按钮"
     },
     "userGuideTitle": {
-        "message": "使用指南",
-        "description": "使用指南标题"
+        "message": "用户指南",
+        "description": "用户指南标题"
     },
     "userGuideStep1": {
-        "message": "点击图标或使用快捷键开始录音",
-        "description": "使用指南步骤1"
+        "message": "单击 BabelFishAI 图标或使用键盘快捷键开始录制",
+        "description": "指南的第 1 步"
     },
     "userGuideStep2": {
-        "message": "对着麦克风说话",
-        "description": "使用指南步骤2"
+        "message": "清晰地对着麦克风讲话",
+        "description": "指南的第 2 步"
     },
     "userGuideStep3": {
-        "message": "再次点击或使用快捷键停止录音",
-        "description": "使用指南步骤3"
+        "message": "再次单击或使用快捷方式停止录制",
+        "description": "指南的第 3 步"
     },
     "userGuideStep4": {
-        "message": "转录文本将按设置显示",
-        "description": "使用指南步骤4"
+        "message": "转录将根据您配置的首选项显示",
+        "description": "指南的第 4 步"
     },
     "userGuideStep5": {
-        "message": "点击复制按钮复制文本",
-        "description": "使用指南步骤5"
+        "message": "使用“复制”按钮将文本复制到剪贴板",
+        "description": "指南的第 5 步"
     },
     "shortcutsTitle": {
-        "message": "快捷键",
-        "description": "快捷键标题"
+        "message": "键盘快捷键",
+        "description": "快捷方式标题"
     },
     "shortcutStartStop": {
-        "message": "开始/停止录音：",
-        "description": "开始停止快捷键"
+        "message": "开始/停止录制：",
+        "description": "主要快捷方式描述"
     },
     "shortcutKeys": {
-        "message": "Ctrl+Shift+1（Mac：⌘+Shift+1）",
-        "description": "快捷键说明"
+        "message": "Ctrl+Shift+1 (Mac 上为 ⌘+Shift+1)",
+        "description": "快捷键描述"
     },
     "aiTranscriptionTitle": {
-        "message": "AI语音转写",
-        "description": "AI转写标题"
+        "message": "人工智能辅助转录",
+        "description": "转录部分标题"
     },
     "aiTranscriptionDesc": {
-        "message": "BabelFishAI使用先进AI技术转写语音。过程分两步进行。",
-        "description": "AI转写说明"
+        "message": "BabelFishAI 使用尖端人工智能将您的声音转录为文本。转录过程分两步进行。",
+        "description": "转录描述"
     },
     "aiTranscriptionStep1": {
-        "message": "通过麦克风录制语音",
-        "description": "转写步骤1"
+        "message": "您的声音通过设备的麦克风录制",
+        "description": "转录的第 1 步"
     },
     "aiTranscriptionStep2": {
-        "message": "使用Whisper AI分析并生成文本",
-        "description": "转写步骤2"
+        "message": "录音由 Whisper AI 分析以生成准确的转录",
+        "description": "转录的第 2 步"
     },
     "aiTranslationTitle": {
-        "message": "AI翻译",
-        "description": "AI翻译标题"
+        "message": "人工智能辅助翻译",
+        "description": "人工智能翻译部分标题"
     },
     "aiTranslationDesc": {
-        "message": "BabelFishAI可使用OpenAI翻译转写文本，保持原意和语境。",
-        "description": "AI翻译说明"
+        "message": "BabelFishAI 还可以借助 OpenAI 的高级人工智能自动翻译您的转录。转录的文本会被分析和翻译，同时保留您话语的含义和上下文。",
+        "description": "翻译描述"
     },
     "authorSectionTitle": {
         "message": "关于作者",
-        "description": "关于作者标题"
+        "description": "作者部分标题"
     },
     "authorName": {
         "message": "Julien LS",
-        "description": "作者名字"
+        "description": "作者姓名"
     },
     "authorRole": {
-        "message": "BabelFishAI开发者",
+        "message": "BabelFishAI 的开发者和创建者",
         "description": "作者角色"
+    },
+    "addModelPlaceholder": {
+        "message": "添加模型",
+        "description": "添加模型占位符"
+    },
+    "addModelButton": {
+        "message": "添加",
+        "description": "添加模型按钮"
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "__MSG_extensionName__",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "__MSG_extensionDescription__",
     "author": "Julien LS",
     "default_locale": "fr",

--- a/src/content.js
+++ b/src/content.js
@@ -307,7 +307,7 @@
                 messages: [
                     {
                         role: "system",
-                        content: `Perform a direct translation from ${sourceLang} to ${targetLang}, without altering URLs. Begin the translation immediately without any introduction or added notes, and ensure not to include any additional information or context beyond the requested translation: '${text}'. Strictly follow the source text without adding, modifying, or omitting elements that are not explicitly present.`
+                        content: `Perform a direct translation from ${sourceLang} to ${targetLang}, without altering URLs. Begin the translation immediately without any introduction or added notes, and ensure not to include any additional information or context beyond the requested translation: ${text}. Strictly follow the source text without adding, modifying, or omitting elements that are not explicitly present.`
                     }
                 ],
                 store: true
@@ -315,7 +315,18 @@
 
             console.log('Translation request payload:', payload);
 
-            const response = await fetch(CONFIG.GPT_API_URL, {
+            // Récupérer l'URL de l'API de traduction depuis le stockage
+            const { translationApiUrl } = await new Promise((resolve) => {
+                chrome.storage.sync.get({
+                    translationApiUrl: CONFIG.GPT_API_URL,
+                }, (result) => {
+                    resolve({
+                        translationApiUrl: result.translationApiUrl || CONFIG.GPT_API_URL,
+                    });
+                });
+            });
+
+            const response = await fetch(translationApiUrl, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/src/content.js
+++ b/src/content.js
@@ -210,7 +210,8 @@
 
         try {
             const formData = new FormData();
-            formData.append('file', audioBlob, 'audio.webm');
+            const timestamp = Date.now();
+            formData.append('file', audioBlob, `audio-${timestamp}.webm`);
             // formData.append('model', CONFIG.WHISPER_MODEL);
 
             // Récupérer l'URL de l'API et le modèle depuis le stockage

--- a/src/content.js
+++ b/src/content.js
@@ -303,12 +303,23 @@
         });
 
         try {
+            // Récupérer le modèle de traduction depuis le stockage
+            const { modelType } = await new Promise((resolve) => {
+                chrome.storage.sync.get({
+                    modelType: CONFIG.GPT_MODEL,
+                }, (result) => {
+                    resolve({
+                        modelType: result.modelType
+                    });
+                });
+            });
+
             const payload = {
-                model: CONFIG.GPT_MODEL,
+                model: modelType,
                 messages: [
                     {
                         role: "system",
-                        content: `Perform a direct translation from ${sourceLang} to ${targetLang}, without altering URLs. Begin the translation immediately without any introduction or added notes, and ensure not to include any additional information or context beyond the requested translation: ${text}. Strictly follow the source text without adding, modifying, or omitting elements that are not explicitly present.`
+                        content: `Perform a direct translation from ${sourceLang} to ${targetLang}, without altering URLs. Begin the translation immediately without any introduction or added notes, and ensure not to include any additional information or context beyond the requested translation: ${text} Strictly follow the source text without adding, modifying, or omitting elements that are not explicitly present.`
                     }
                 ],
                 store: true

--- a/src/pages/options/options.html
+++ b/src/pages/options/options.html
@@ -153,15 +153,21 @@
             <h2 data-i18n="advancedConfigTitle">Configuration Avancée</h2>
             <div class="form-group">
                 <label for="modelType" data-i18n="translationModelLabel">Modèle de traduction :</label>
-                <select id="modelType">
-                    <option value="gpt-4o-mini">gpt-4o-mini (par défaut)</option>
-                    <option value="gpt-4o">gpt-4o</option>
-                </select>
+                <div id="modelTypeContainer">
+                    <select id="modelType">
+                        <option value="gpt-4o-mini">gpt-4o-mini (par défaut)</option>
+                        <option value="gpt-4o">gpt-4o</option>
+                    </select>
+                    <input type="text" id="newModelType" placeholder="Ajouter un modèle"
+                        data-i18n-placeholder="addModelPlaceholder">
+                    <button type="button" id="addModelType" data-i18n="addModelButton">Ajouter</button>
+                    <div id="customModelsList">
+                    </div>
+                </div>
             </div>
             <div class="form-group">
                 <label for="audioModelType" data-i18n="audioModelLabel">Modèle audio :</label>
                 <select id="audioModelType">
-                    <!-- Les options seront ajoutées dynamiquement -->
                 </select>
             </div>
             <div class="form-group">
@@ -181,7 +187,6 @@
             <div class="form-group">
                 <label data-i18n="forcedDialogDomainsLabel">Domaines avec boîte de dialogue forcée :</label>
                 <div class="domains-list" id="domainsList">
-                    <!-- Les domaines seront ajoutés ici dynamiquement -->
                 </div>
                 <div class="domain-input-container">
                     <input type="text" id="newDomain" data-i18n-placeholder="addDomainPlaceholder">

--- a/src/utils/translation.js
+++ b/src/utils/translation.js
@@ -56,7 +56,7 @@ window.BabelFishAIUtils = window.BabelFishAIUtils || {};
                 messages: [
                     {
                         role: "system",
-                        content: `Perform a direct translation from ${sourceLang} to ${targetLang}, without altering URLs. Begin the translation immediately without any introduction or added notes, and ensure not to include any additional information or context beyond the requested translation: '${text}'. Strictly follow the source text without adding, modifying, or omitting elements that are not explicitly present.`
+                        content: `Perform a direct translation from ${sourceLang} to ${targetLang}, without altering URLs. Begin the translation immediately without any introduction or added notes, and ensure not to include any additional information or context beyond the requested translation: ${text}. Strictly follow the source text without adding, modifying, or omitting elements that are not explicitly present.`
                     }
                 ],
                 store: true


### PR DESCRIPTION
manifest.json:

Augmentation de la version de l'extension de 1.1.1 à 1.1.2.
src/content.js:

Ajout d'un timestamp au nom du fichier audio envoyé à l'API Whisper (contournement du cache pour les URL privées, comme LiteLLM).
Utilisation de l'URL de traduction stockée dans les options (au lieu d'une constante).
Utilisation du modèle de traduction sélectionné dans les options (au lieu d'une constante).
Suppression d'un point en trop dans le prompt de traduction.
src/pages/options/options.html:

Ajout d'un champ et d'un bouton pour ajouter des modèles de traduction personnalisés.
Ajout d'attributs data-i18n pour la traduction.
Modification de la structure HTML.
src/pages/options/options.js:

Ajout de la logique pour gérer les modèles personnalisés (charger, afficher, ajouter, supprimer, sauvegarder).
Mise à jour de la liste déroulante des modèles.
src/utils/translation.js:

Suppression d'un point en trop dans le prompt de traduction (redondant).
_locales/*/messages.json:

Ajout des traductions pour le nouveau champ et bouton.
