### PR TITLE
1.1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Babel Fish AI est une extension Chrome innovante conçue à l'origine pour offrir une transcription vocale puissante. Transformez votre voix en texte avec une précision remarquable grâce à l’API Whisper d’OpenAI, et bénéficiez en option d’une traduction automatique en temps réel. Vous pouvez utiliser Babel Fish AI exclusivement pour la transcription ou activer la traduction à la volée selon vos besoins.
 
-[![CodeFactor](https://www.codefactor.io/repository/github/jls42/babelfishai/badge)](https://www.codefactor.io/repository/github/jls42/babelfishai)
+[![CodeFactor](https://www.codefactor.io/repository/github/jls42/babelfishai/badge)](https://www.codefactor.io/repository/github/jls42/babelfishai) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/59bfe4cd13444ee1b4cffa58300dd043)](https://app.codacy.com/gh/jls42/BabelFishAI/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 ## 🌟 Fonctionnalités
 

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -151,6 +151,10 @@
         "message": "الترجمة المتكاملة بالذكاء الاصطناعي",
         "description": "عنوان قسم الترجمة"
     },
+    "automaticLanguage": {
+        "message": "تلقائي",
+        "description": "خيار اللغة التلقائية"
+    },
     "enableTranslationLabel": {
         "message": "تمكين الترجمة التلقائية",
         "description": "تسمية لتمكين الترجمة"

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -151,6 +151,10 @@
         "message": "Integrierte KI-Übersetzung",
         "description": "Titel des Übersetzungsabschnitts"
     },
+    "automaticLanguage": {
+        "message": "Automatisch",
+        "description": "Option für automatische Sprache"
+    },
     "enableTranslationLabel": {
         "message": "Automatische Übersetzung aktivieren",
         "description": "Label zum Aktivieren der Übersetzung"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -151,6 +151,10 @@
         "message": "Integrated AI Translation",
         "description": "Title of the translation section"
     },
+    "automaticLanguage": {
+        "message": "Automatic",
+        "description": "Automatic language option"
+    },
     "enableTranslationLabel": {
         "message": "Enable automatic translation",
         "description": "Label to enable translation"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -151,6 +151,10 @@
         "message": "Traducción IA Integrada",
         "description": "Título de la sección de traducción"
     },
+    "automaticLanguage": {
+        "message": "Automático",
+        "description": "Opción de idioma automático"
+    },
     "enableTranslationLabel": {
         "message": "Habilitar la traducción automática",
         "description": "Etiqueta para habilitar la traducción"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -151,6 +151,10 @@
         "message": "Traduction IA Intégrée",
         "description": "Titre de la section traduction"
     },
+    "automaticLanguage": {
+        "message": "Automatique",
+        "description": "Option de langue automatique"
+    },
     "enableTranslationLabel": {
         "message": "Activer la traduction automatique",
         "description": "Label pour activer la traduction"

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -151,6 +151,10 @@
         "message": "एकीकृत एआई अनुवाद",
         "description": "अनुवाद अनुभाग का शीर्षक"
     },
+    "automaticLanguage": {
+        "message": "स्वचालित",
+        "description": "स्वचालित भाषा विकल्प"
+    },
     "enableTranslationLabel": {
         "message": "स्वचालित अनुवाद सक्षम करें",
         "description": "अनुवाद सक्षम करने के लिए लेबल"

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -151,6 +151,10 @@
         "message": "Traduzione IA Integrata",
         "description": "Titolo della sezione di traduzione"
     },
+    "automaticLanguage": {
+        "message": "Automatico",
+        "description": "Opzione lingua automatica"
+    },
     "enableTranslationLabel": {
         "message": "Abilita la traduzione automatica",
         "description": "Etichetta per abilitare la traduzione"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -151,6 +151,10 @@
         "message": "統合 AI 翻訳",
         "description": "翻訳セクションのタイトル"
     },
+    "automaticLanguage": {
+        "message": "自動",
+        "description": "自動言語オプション"
+    },
     "enableTranslationLabel": {
         "message": "自動翻訳を有効にする",
         "description": "翻訳を有効にするためのラベル"

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -151,6 +151,10 @@
         "message": "통합 AI 번역",
         "description": "번역 섹션 제목"
     },
+    "automaticLanguage": {
+        "message": "자동",
+        "description": "자동 언어 옵션"
+    },
     "enableTranslationLabel": {
         "message": "자동 번역 활성화",
         "description": "번역 활성화 레이블"

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -151,6 +151,10 @@
         "message": "Geïntegreerde AI-vertaling",
         "description": "Titel van de vertaalsectie"
     },
+    "automaticLanguage": {
+        "message": "Automatisch",
+        "description": "Optie voor automatische taal"
+    },
     "enableTranslationLabel": {
         "message": "Automatische vertaling inschakelen",
         "description": "Label om vertaling in te schakelen"

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -151,6 +151,10 @@
         "message": "Zintegrowane Tłumaczenie AI",
         "description": "Tytuł sekcji tłumaczenia"
     },
+    "automaticLanguage": {
+        "message": "Automatycznie",
+        "description": "Opcja języka automatycznego"
+    },
     "enableTranslationLabel": {
         "message": "Włącz automatyczne tłumaczenie",
         "description": "Etykieta włączania tłumaczenia"

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -151,6 +151,10 @@
         "message": "Tradução IA Integrada",
         "description": "Título da seção de tradução"
     },
+    "automaticLanguage": {
+        "message": "Automático",
+        "description": "Opção de idioma automático"
+    },
     "enableTranslationLabel": {
         "message": "Ativar tradução automática",
         "description": "Rótulo para ativar a tradução"

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -151,6 +151,10 @@
         "message": "Traducere AI Integrată",
         "description": "Titlul secțiunii de traducere"
     },
+    "automaticLanguage": {
+        "message": "Automată",
+        "description": "Opțiune pentru limba automată"
+    },
     "enableTranslationLabel": {
         "message": "Activați traducerea automată",
         "description": "Etichetă pentru activarea traducerii"

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -151,6 +151,10 @@
         "message": "Integrerad AI-översättning",
         "description": "Titel för översättningsavsnittet"
     },
+    "automaticLanguage": {
+        "message": "Automatisk",
+        "description": "Alternativ för automatiskt språk"
+    },
     "enableTranslationLabel": {
         "message": "Aktivera automatisk översättning",
         "description": "Etikett för att aktivera översättning"

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -151,6 +151,10 @@
         "message": "集成 AI 翻译",
         "description": "翻译部分的标题"
     },
+    "automaticLanguage": {
+        "message": "自动",
+        "description": "自动语言选项"
+    },
     "enableTranslationLabel": {
         "message": "启用自动翻译",
         "description": "启用翻译的标签"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "__MSG_extensionName__",
-    "version": "1.1.9",
+    "version": "1.1.10",
     "description": "__MSG_extensionDescription__",
     "author": "Julien LS",
     "default_locale": "fr",

--- a/src/pages/options/options.html
+++ b/src/pages/options/options.html
@@ -109,6 +109,7 @@
                     <div class="language-select">
                         <label for="sourceLanguage" data-i18n="sourceLanguageLabel">Langue source :</label>
                         <select id="sourceLanguage">
+                            <option value="auto" data-i18n="automaticLanguage">Automatique</option>
                             <option value="fr">Français (fr)</option>
                             <option value="en">English (en)</option>
                             <option value="es">Español (es)</option>

--- a/src/pages/options/options.js
+++ b/src/pages/options/options.js
@@ -89,7 +89,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             bannerColorEnd: '#4c7b8d',
             bannerOpacity: 80,
             enableTranslation: false,
-            sourceLanguage: 'fr',
+            sourceLanguage: 'auto',
             targetLanguage: 'en',
             expertMode: false,
             modelType: 'gpt-4o-mini',
@@ -107,7 +107,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             bannerColorEndInput.value = items.bannerColorEnd;
             bannerOpacityInput.value = items.bannerOpacity;
             enableTranslationCheckbox.checked = items.enableTranslation;
-            sourceLanguageSelect.value = items.sourceLanguage;
+            sourceLanguageSelect.value = items.sourceLanguage || 'auto';
             targetLanguageSelect.value = items.targetLanguage;
             expertModeCheckbox.checked = items.expertMode;
             modelTypeSelect.value = items.modelType;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -20,7 +20,6 @@ window.BabelFishAIUtils = window.BabelFishAIUtils || {};
      * @param {string} [options.errorType=ERRORS.API_ERROR] - Type d'erreur à utiliser en cas d'échec
      * @param {Function} [options.responseProcessor] - Fonction pour traiter la réponse avant de la renvoyer
      * @param {boolean} [options.retryOnFail=false] - Si true, réessaiera une fois en cas d'échec
-     * @param {number} [options.timeout=10000] - Délai d'expiration en ms
      * @returns {Promise<any>} Résultat traité de l'appel API
      * @throws {Error} Une erreur avec le message approprié en cas d'échec de l'appel
      */
@@ -34,7 +33,6 @@ window.BabelFishAIUtils = window.BabelFishAIUtils || {};
             errorType = ERRORS.API_ERROR,
             responseProcessor = (data) => data,
             retryOnFail = false,
-            timeout = 10000
         } = options;
 
         if (!apiKey) {
@@ -92,14 +90,11 @@ window.BabelFishAIUtils = window.BabelFishAIUtils || {};
                     body
                 };
 
-                // Créer une promesse qui se résout avec la réponse ou rejette après timeout
+                // Effectuer l'appel API avec gestion des erreurs réseau et timeout
                 const fetchPromise = fetch(url, requestOptions);
-                const timeoutPromise = new Promise((_, reject) => {
-                    setTimeout(() => reject(new Error(`${errorType}: Timeout - Request exceeded ${timeout}ms`)), timeout);
-                });
 
                 // Effectuer l'appel API avec gestion des erreurs réseau et timeout
-                const response = await Promise.race([fetchPromise, timeoutPromise]);
+                const response = await fetchPromise;
 
                 // Gérer les erreurs HTTP
                 if (!response.ok) {

--- a/src/utils/translation.js
+++ b/src/utils/translation.js
@@ -50,7 +50,7 @@ window.BabelFishAIUtils = window.BabelFishAIUtils || {};
                 translationApiUrl: window.BabelFishAIConstants.API_CONFIG.DEFAULT_GPT_API_URL,
                 disableLogging: false
             });
-            
+
             const { modelType, translationApiUrl, disableLogging } = result;
 
             // Préparer les messages pour l'API
@@ -61,7 +61,9 @@ window.BabelFishAIUtils = window.BabelFishAIUtils || {};
                 },
                 {
                     role: "user",
-                    content: `Perform a direct translation from ${sourceLang} to ${targetLang}, without altering URLs. Strictly follow the source text without adding, modifying, or omitting elements that are not explicitly present. Begin the translation immediately without any introduction or added notes, and ensure not to include any additional information or context beyond the requested translation: ${text}`
+                    content: sourceLang === 'auto'
+                        ? `Translate the following text to ${targetLang}, without altering URLs. Strictly follow the source text without adding, modifying, or omitting elements that are not explicitly present. Begin the translation immediately without any introduction or added notes, and ensure not to include any additional information or context beyond the requested translation: ${text}`
+                        : `Perform a direct translation from ${sourceLang} to ${targetLang}, without altering URLs. Strictly follow the source text without adding, modifying, or omitting elements that are not explicitly present. Begin the translation immediately without any introduction or added notes, and ensure not to include any additional information or context beyond the requested translation: ${text}`
                 }
             ];
 
@@ -102,7 +104,7 @@ window.BabelFishAIUtils = window.BabelFishAIUtils || {};
 
             debugTranslation('Translation successful, length:', translationResponse.length);
             return translationResponse;
-            
+
         } catch (error) {
             console.error('Translation error:', error);
             // Si l'erreur est déjà formatée, la propager directement


### PR DESCRIPTION
Ajout de l'option 'Automatique' pour la langue source dans les paramètres de traduction.

Ajout de l'option 'Automatique' au menu déroulant de la langue source dans la page d'options.
Ajout de la traduction pour l'option 'Automatique' dans tous les fichiers messages.json pour toutes les langues prises en charge.
Modification de la fonction translateText dans translation.js pour gérer le mode 'Automatique' pour la langue source, en utilisant un prompt GPT adapté.
Définition de la langue source par défaut sur 'Automatique' dans options.js.
Ces changements permettent à l'utilisateur de laisser la détection de la langue source en mode automatique, simplifiant l'utilisation de l'extension pour la traduction.

Fix : 
Le timeout de 10 secondes configuré pour les appels API dans `src/utils/api.js` a été ajouté par erreur.
Suppression complète du timeout pour permettre des transcriptions plus longues sans interruption.

