### PR TITLE
1.1.15

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "__MSG_extensionName__",
-    "version": "1.1.14",
+    "version": "1.1.15",
     "description": "__MSG_extensionDescription__",
     "author": "Julien LS",
     "default_locale": "fr",


### PR DESCRIPTION
  Fix: Améliore la gestion de la copie automatique selon le contexte

  Améliore le comportement de l'option "Copie automatique dans le presse-papiers" pour qu'elle fonctionne de manière plus intuitive et contextuelle:

  - Ne copie plus automatiquement lorsque le texte est inséré dans un champ de saisie
  - Copie automatiquement uniquement lorsque la boîte de dialogue est affichée ET qu'aucun champ de saisie n'est en focus
  - Améliore la détection des champs de saisie valides (inputs, textareas, éléments contentEditable)
  - Respecte les préférences d'affichage de l'utilisateur (force l'affichage en dialogue sur certains domaines)

  Cette modification assure une meilleure expérience utilisateur en évitant de remplacer le contenu du presse-papiers inutilement lorsque le texte est déjà inséré dans un champ.