### PR TITLE
fix: add skipcq comments for DeepSource false positives

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -65,7 +65,7 @@ let isRecording = false;
  */
 function debug(...args) {
     if (SERVICE_WORKER_CONFIG.DEBUG) {
-        console.log('[Background]', ...args);
+        console.log('[Background]', ...args); // skipcq: JS-0002 - Debug function, only active when DEBUG=true
     }
 }
 

--- a/src/utils/api-utils.js
+++ b/src/utils/api-utils.js
@@ -3,7 +3,7 @@
 globalThis.BabelFishAIUtils = globalThis.BabelFishAIUtils || {};
 
 (function (exports) {
-    'use strict';
+    'use strict'; // skipcq: JS-0118 - 'use strict' inside IIFE is intentional for module isolation
 
     // Constantes importées depuis l'espace global
     const ERRORS = globalThis.BabelFishAIConstants.ERRORS;


### PR DESCRIPTION
## Summary
- Add skipcq comment for JS-0002 (console.log in debug function)
- Add skipcq comment for JS-0118 ('use strict' in IIFE)

## Details
- `background.js:68` - Debug console is intentional, only active when DEBUG=true
- `api-utils.js:6` - 'use strict' inside IIFE is standard pattern for module isolation