### PR TITLE
docs: update privacy policy for Firefox support

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,15 +1,15 @@
 # Politique de Confidentialité de BabelFishAI
 
-**Date d'entrée en vigueur : 13 décembre 2025**
+**Date d'entrée en vigueur : 16 décembre 2025**
 
-Cette Politique de Confidentialité explique comment BabelFishAI ("l'Extension", "nous", "notre") gère vos informations lorsque vous utilisez notre extension Chrome. BabelFishAI agit comme une interface *transparente* entre votre navigateur Chrome et les services de transcription/traduction des providers IA que vous configurez (Mistral AI, OpenAI, ou un service personnalisé). **Nous ne stockons *aucune* de vos données (enregistrements vocaux, transcriptions, clés API) sur nos serveurs ni sur aucun autre support.** Vos clés API sont stockées *localement* sur votre ordinateur.
+Cette Politique de Confidentialité explique comment BabelFishAI ("l'Extension", "nous", "notre") gère vos informations lorsque vous utilisez notre extension de navigateur (Chrome ou Firefox). BabelFishAI agit comme une interface *transparente* entre votre navigateur et les services de transcription/traduction des providers IA que vous configurez (Mistral AI, OpenAI, ou un service personnalisé). **Nous ne stockons *aucune* de vos données (enregistrements vocaux, transcriptions, clés API) sur nos serveurs ni sur aucun autre support.** Vos clés API sont stockées *localement* sur votre ordinateur.
 
 ## 1. Informations Traitées par l'Extension
 
 Lorsque vous utilisez BabelFishAI, les informations suivantes *transitent* par l'extension, *sans être stockées* :
 
 *   **Votre voix :** Si vous utilisez la fonction d'enregistrement, nous accédons à votre microphone et *transmettons* votre voix *directement* au service de transcription du provider configuré (Mistral AI, OpenAI, ou votre service personnalisé).
-*   **Transcription de votre voix :** Le service de transcription (Voxtral pour Mistral AI, Whisper pour OpenAI) transforme votre enregistrement vocal en texte. Ce texte *transite* par l'extension, *sans être stocké*.
+*   **Transcription de votre voix :** Le service de transcription du provider configuré transforme votre enregistrement vocal en texte. Ce texte *transite* par l'extension, *sans être stocké*.
 *   **Traduction, reformulation ou correction (facultatif) :** Si vous activez ces fonctionnalités, le texte est *transmis* au service de chat du provider configuré. Le résultat *transite* par l'extension, *sans être stocké*.
 *   **Vos clés API :** Selon le provider que vous utilisez (Mistral AI, OpenAI), vous devez fournir votre clé API. Ces clés sont stockées localement sur votre ordinateur et ne sont *transmises* qu'au provider correspondant.
 *   **Vos paramètres :** Vos préférences (providers, modèles, langues, couleurs, etc.) sont stockées localement sur votre ordinateur.
@@ -34,11 +34,11 @@ Les informations qui *transitent* par BabelFishAI sont utilisées *uniquement* p
 
 *   Vos clés API (Mistral AI, OpenAI) sont stockées localement sur votre ordinateur et ne sont transmises qu'au provider correspondant.
 *   Les communications avec les services de transcription et de traduction sont sécurisées (HTTPS) si vous utilisez les paramètres par défaut ou une URL personnalisée valide commençant par HTTPS.
-*   **Aucune donnée n'est stockée par l'extension.** Les enregistrements audio sont transmis *directement* au service de transcription. Bien que nous prenions toutes les mesures raisonnables pour supprimer immédiatement les données de la mémoire vive de l'extension, nous ne pouvons pas garantir l'absence totale de traces résiduelles dans la mémoire du navigateur Chrome, en raison du fonctionnement interne de Chrome.
+*   **Aucune donnée n'est stockée par l'extension.** Les enregistrements audio sont transmis *directement* au service de transcription. Bien que nous prenions toutes les mesures raisonnables pour supprimer immédiatement les données de la mémoire vive de l'extension, nous ne pouvons pas garantir l'absence totale de traces résiduelles dans la mémoire du navigateur, en raison du fonctionnement interne des navigateurs.
 
 ## 5. Vos Choix
 
-*   Vous pouvez désactiver l'accès au microphone dans les paramètres de votre navigateur Chrome.
+*   Vous pouvez désactiver l'accès au microphone dans les paramètres de votre navigateur.
 *   Vous pouvez désactiver la traduction dans les paramètres de l'extension.
 *   Vous pouvez supprimer vos clés API (Mistral AI, OpenAI) des paramètres de l'extension.
 *   Vous pouvez choisir le provider IA que vous souhaitez utiliser (Mistral AI, OpenAI, ou service personnalisé). Vérifiez *attentivement* leurs politiques de confidentialité et assurez-vous qu'ils utilisent HTTPS et offrent des garanties de sécurité suffisantes.
@@ -68,7 +68,7 @@ BabelFishAI ne stocke *aucune* donnée personnelle. Par conséquent, nous ne pou
 
 ## 9. Durée de Conservation
 
-**BabelFishAI ne conserve aucune donnée.** Les enregistrements audio sont transmis directement au service de transcription et ne sont pas conservés par l'extension. Bien que nous prenions toutes les mesures raisonnables pour supprimer immédiatement les données de la mémoire vive de l'extension, nous ne pouvons pas garantir l'absence totale de traces résiduelles dans la mémoire du navigateur Chrome, en raison du fonctionnement interne de Chrome et de votre système d'exploitation. Vos clés API sont stockées localement sur votre ordinateur et ne sont conservées que tant que vous utilisez l'extension et ne les supprimez pas manuellement.
+**BabelFishAI ne conserve aucune donnée.** Les enregistrements audio sont transmis directement au service de transcription et ne sont pas conservés par l'extension. Bien que nous prenions toutes les mesures raisonnables pour supprimer immédiatement les données de la mémoire vive de l'extension, nous ne pouvons pas garantir l'absence totale de traces résiduelles dans la mémoire du navigateur, en raison du fonctionnement interne des navigateurs et de votre système d'exploitation. Vos clés API sont stockées localement sur votre ordinateur et ne sont conservées que tant que vous utilisez l'extension et ne les supprimez pas manuellement.
 
 ## 10. Transferts Internationaux de Données
 
@@ -94,14 +94,14 @@ Vous avez le droit de déposer une plainte auprès de la CNIL si vous estimez qu
 
 Bien que BabelFishAI ne conserve aucune donnée, voici quelques conseils généraux pour vider la mémoire de votre navigateur et de votre système :
 
-*   **Redémarrez Chrome:** Fermer et rouvrir Chrome efface la mémoire vive utilisée par le navigateur.
-*   **Redémarrez votre ordinateur:** Un redémarrage complet efface la mémoire vive de l'ensemble du système.
-*   **Utilisez les outils de Chrome:** Chrome dispose d'outils intégrés pour gérer la mémoire (chrome://memory-internals/ , mais leur utilisation est *très* technique).  En général, le redémarrage est plus simple et suffisant.
-* **Evitez d'utiliser des versions de Chrome qui ne sont plus maintenues et qui pourraient contenir des failles de sécurité**
-* **Utilisez un système d'exploitation récent**
+*   **Redémarrez votre navigateur :** Fermer et rouvrir Chrome ou Firefox efface la mémoire vive utilisée par le navigateur.
+*   **Redémarrez votre ordinateur :** Un redémarrage complet efface la mémoire vive de l'ensemble du système.
+*   **Utilisez les outils intégrés :** Les navigateurs disposent d'outils pour gérer la mémoire, mais leur utilisation est *très* technique. En général, le redémarrage est plus simple et suffisant.
+*   **Gardez votre navigateur à jour :** Évitez d'utiliser des versions de Chrome ou Firefox qui ne sont plus maintenues et qui pourraient contenir des failles de sécurité.
+*   **Utilisez un système d'exploitation récent.**
 
 **Note :** Ces actions n'ont *pas* d'impact sur les données traitées par votre provider IA (Mistral AI, OpenAI, ou service personnalisé). Elles concernent uniquement la mémoire *locale* de votre ordinateur.
 
 ## 14. Modifications de cette Politique
 
-Nous pouvons mettre à jour cette Politique de Confidentialité. Si nous apportons des modifications importantes, nous vous en informerons via les options de l'extension ou sur la page de l'extension dans le Chrome Web Store.
+Nous pouvons mettre à jour cette Politique de Confidentialité. Si nous apportons des modifications importantes, nous vous en informerons via les options de l'extension ou sur la page de l'extension dans le Chrome Web Store ou Firefox Add-ons.


### PR DESCRIPTION
## Summary
- Add Firefox alongside Chrome throughout the privacy policy
- Remove specific model names (Voxtral, Whisper) for flexibility
- Update effective date to December 16, 2025